### PR TITLE
Smart ptr refactor

### DIFF
--- a/src/controller/CalibrationController.cpp
+++ b/src/controller/CalibrationController.cpp
@@ -10,6 +10,7 @@
 #include "Visualizer.h"
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
+#include <memory>
 
 
 controller::CalibrationController::CalibrationController(std::shared_ptr<camera::ICamera> camera,
@@ -23,7 +24,7 @@ controller::CalibrationController::CalibrationController(std::shared_ptr<camera:
 
 void controller::CalibrationController::run() {
     scan();
-    std::vector<pcl::PointCloud<pcl::PointXYZ>::Ptr, Eigen::aligned_allocator<pcl::PointCloud<pcl::PointXYZ>::Ptr>> cloud_vector;
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector;
     file_handler->load_clouds(cloud_vector, CloudType::Type::CALIBRATION);
     equations::Normal axis_dir = model->calculate_axis_dir(ground_planes);
     equations::Point center = model->calculate_center_pt(axis_dir, upright_planes);
@@ -43,7 +44,7 @@ void controller::CalibrationController::scan() {
         std::string name = std::to_string(i * deg) + ".pcd";
         camera->scan();
         std::vector<uint16_t> depth_frame = camera->get_depth_frame_processed();
-        pcl::PointCloud<pcl::PointXYZ>::Ptr cloud = model->create_point_cloud(depth_frame, intrin);
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud = model->create_point_cloud(depth_frame, intrin);
         cloud = model->crop_cloud(cloud, min_x, max_x, min_y, max_y, min_z, max_z);
         cloud = model->voxel_grid_filter(cloud, .003);
 

--- a/src/controller/FilterTestingController.cpp
+++ b/src/controller/FilterTestingController.cpp
@@ -22,7 +22,7 @@ void controller::FilterTestingController::run() {
     std::vector<uint16_t> depth_frame = camera->get_depth_frame();
     std::vector<uint16_t> depth_frame_processed = camera->get_depth_frame_processed();
     const camera::intrinsics intrin2 = camera->get_intrinsics_processed();
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud1 = model->create_point_cloud(depth_frame, intrin);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud2 = model->create_point_cloud(depth_frame_processed, intrin2);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud1 = model->create_point_cloud(depth_frame, intrin);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud2 = model->create_point_cloud(depth_frame_processed, intrin2);
     viewer->compareVis(cloud1, cloud2);
 }

--- a/src/controller/ProcessingController.cpp
+++ b/src/controller/ProcessingController.cpp
@@ -59,7 +59,7 @@ void controller::ProcessingController::register_all_clouds(CloudType::Type cloud
 
         source = cloud_vector[i - 1];
         target = cloud_vector[i];
-        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> temp_registered(new pcl::PointCloud<pcl::PointXYZ>);
+        auto temp_registered = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
 
         Eigen::Matrix4f transform = model->icp_register_pair_clouds(source, target, temp_registered);
         Eigen::Matrix4f targetToSource = transform.inverse();
@@ -85,14 +85,12 @@ void controller::ProcessingController::rotate_all_clouds(CloudType::Type cloud_t
     std::vector<float> direction = calibration_json["axis direction"];
     float theta = -(float) info_json["angle"] * (M_PI / 180.0);
 
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
-            global_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    auto global_cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     *global_cloud = *cloud_vector[0];
     for (int i = 1; i < cloud_vector.size(); i++) {
-        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
-                rotated(new pcl::PointCloud<pcl::PointXYZ>);
+        pcl::PointCloud<pcl::PointXYZ> rotated;
         rotated = model->rotate_cloud_about_line(cloud_vector[i], origin, direction, theta * i);
-        *global_cloud += *rotated;
+        *global_cloud += rotated;
     }
 
     viewer->simpleVis(global_cloud);

--- a/src/controller/ProcessingController.cpp
+++ b/src/controller/ProcessingController.cpp
@@ -3,8 +3,8 @@
 #include "ScanFileHandler.h"
 #include "Model.h"
 #include "Constants.h"
-
 #include <pcl/common/transforms.h>
+#include <memory>
 #include <nlohmann/json.hpp>
 
 using json = nlohmann::json;
@@ -21,23 +21,25 @@ void controller::ProcessingController::run() {
 void controller::ProcessingController::crop_clouds(CloudType::Type cloud_type) {
     using namespace constants;
 
-    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>, Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>>> cloud_vector;
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector;
     file_handler->load_clouds(cloud_vector, cloud_type);
     for (int i = 0; i < cloud_vector.size(); i++) {
-        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cropped_cloud = model->crop_cloud(cloud_vector[i],
-                                                                              min_x, max_x,
-                                                                              min_y, max_y,
-                                                                              min_z, max_z);
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+                cropped_cloud = model->crop_cloud(cloud_vector[i],
+                                                  min_x, max_x,
+                                                  min_y, max_y,
+                                                  min_z, max_z);
         std::cout << "saving cropped cloud to" << std::endl;
         file_handler->save_cloud(cropped_cloud, std::to_string(i) + ".pcd", CloudType::Type::PROCESSED);
     }
 }
 
 void controller::ProcessingController::remove_planes(CloudType::Type cloud_type) {
-    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>, Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>>> cloud_vector;
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector;
     file_handler->load_clouds(cloud_vector, cloud_type);
     for (int i = 0; i < cloud_vector.size(); i++) {
-        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> segmented_cloud = model->remove_plane(cloud_vector[i]);
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+                segmented_cloud = model->remove_plane(cloud_vector[i]);
         std::cout << "saving segmented cloud" << std::endl;
         file_handler->save_cloud(segmented_cloud, std::to_string(i) + ".pcd", CloudType::Type::PROCESSED);
     }
@@ -45,12 +47,13 @@ void controller::ProcessingController::remove_planes(CloudType::Type cloud_type)
 
 
 void controller::ProcessingController::register_all_clouds(CloudType::Type cloud_type) {
-    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>, Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>>> cloud_vector;
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector;
     file_handler->load_clouds(cloud_vector, cloud_type);
     Eigen::Matrix4f global_transform = Eigen::Matrix4f::Identity();
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> result(new pcl::PointCloud<pcl::PointXYZ>), source, target;
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> global_cloud(new pcl::PointCloud<pcl::PointXYZ>);
-
+    auto source = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto target = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto result = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto global_cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
 
     for (int i = 1; i < cloud_vector.size(); i++) {
 
@@ -73,7 +76,7 @@ void controller::ProcessingController::register_all_clouds(CloudType::Type cloud
 }
 
 void controller::ProcessingController::rotate_all_clouds(CloudType::Type cloud_type) {
-    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>, Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>>> cloud_vector;
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector;
     file_handler->load_clouds(cloud_vector, cloud_type);
     json info_json = file_handler->get_info_json();
     json calibration_json = file_handler->get_calibration_json();
@@ -82,10 +85,12 @@ void controller::ProcessingController::rotate_all_clouds(CloudType::Type cloud_t
     std::vector<float> direction = calibration_json["axis direction"];
     float theta = -(float) info_json["angle"] * (M_PI / 180.0);
 
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> global_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+            global_cloud(new pcl::PointCloud<pcl::PointXYZ>);
     *global_cloud = *cloud_vector[0];
     for (int i = 1; i < cloud_vector.size(); i++) {
-        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> rotated(new pcl::PointCloud<pcl::PointXYZ>);
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+                rotated(new pcl::PointCloud<pcl::PointXYZ>);
         rotated = model->rotate_cloud_about_line(cloud_vector[i], origin, direction, theta * i);
         *global_cloud += *rotated;
     }

--- a/src/controller/ProcessingController.h
+++ b/src/controller/ProcessingController.h
@@ -67,7 +67,7 @@ namespace controller {
         void rotate_all_clouds(CloudType::Type cloud_type);
 
 
-        void visualize_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud);
+        void visualize_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud);
 
     private:
         std::shared_ptr<model::Model> model;

--- a/src/controller/ScanController.cpp
+++ b/src/controller/ScanController.cpp
@@ -47,8 +47,8 @@ void controller::ScanController::scan() {
         camera->scan();
         std::vector<uint16_t> depth_frame_raw = camera->get_depth_frame();
         std::vector<uint16_t> depth_frame_filt = camera->get_depth_frame_processed();
-        pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_raw = model->create_point_cloud(depth_frame_raw, intrin);
-        pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_filt = model->create_point_cloud(depth_frame_filt, intrin);
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud_raw = model->create_point_cloud(depth_frame_raw, intrin);
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud_filt = model->create_point_cloud(depth_frame_filt, intrin);
 
         file_handler->save_cloud(cloud_raw, name, CloudType::Type::RAW);
         file_handler->save_cloud(cloud_filt, name, CloudType::Type::FILTERED);

--- a/src/file/CalibrationFileHandler.cpp
+++ b/src/file/CalibrationFileHandler.cpp
@@ -31,7 +31,7 @@ file::CalibrationFileHandler::CalibrationFileHandler(const char *scan_name) {
     }
 }
 
-void file::CalibrationFileHandler::save_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr &cloud,
+void file::CalibrationFileHandler::save_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                                               const std::string &cloud_name,
                                               CloudType::Type cloud_type) {
     std::cout << "saving file to ";
@@ -40,7 +40,7 @@ void file::CalibrationFileHandler::save_cloud(pcl::PointCloud<pcl::PointXYZ>::Pt
     pcl::io::savePCDFileASCII(out_path.string(), *cloud);
 }
 
-void file::CalibrationFileHandler::load_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+void file::CalibrationFileHandler::load_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                               const std::string &cloud_name,
                                               CloudType::Type cloud_type) {
     path open_path = scan_folder_path / cloud_name;
@@ -50,7 +50,7 @@ void file::CalibrationFileHandler::load_cloud(pcl::PointCloud<pcl::PointXYZ>::Pt
 }
 
 void file::CalibrationFileHandler::load_clouds(
-        std::vector<pcl::PointCloud<pcl::PointXYZ>::Ptr, Eigen::aligned_allocator<pcl::PointCloud<pcl::PointXYZ>::Ptr>> &cloud_vector,
+        std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>, Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>>> &cloud_vector,
         CloudType::Type cloud_type) {
     std::vector<path> cloud_paths;
     path load_path = scan_folder_path;
@@ -68,7 +68,7 @@ void file::CalibrationFileHandler::load_clouds(
 
     // finally we load the clouds into the cloud_vector
     for (auto &p : cloud_paths) {
-        pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+        auto cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
         if (pcl::io::loadPCDFile<pcl::PointXYZ>(p.string(), *cloud) == -1) {
             PCL_ERROR ("Couldn't read file \n");
         }

--- a/src/file/CalibrationFileHandler.cpp
+++ b/src/file/CalibrationFileHandler.cpp
@@ -50,7 +50,7 @@ void file::CalibrationFileHandler::load_cloud(std::shared_ptr<pcl::PointCloud<pc
 }
 
 void file::CalibrationFileHandler::load_clouds(
-        std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>, Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>>> &cloud_vector,
+        std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &cloud_vector,
         CloudType::Type cloud_type) {
     std::vector<path> cloud_paths;
     path load_path = scan_folder_path;

--- a/src/file/CalibrationFileHandler.h
+++ b/src/file/CalibrationFileHandler.h
@@ -33,17 +33,17 @@ namespace file {
          */
         CalibrationFileHandler(const char *scan_name);
 
-        void save_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr &cloud,
+        void save_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                         const std::string &cloud_name,
                         CloudType::Type cloud_type) override;
 
-        void load_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+        void load_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                         const std::string &cloud_name,
                         CloudType::Type cloud_type) override;
 
         void load_clouds(
-                std::vector<pcl::PointCloud<pcl::PointXYZ>::Ptr,
-                        Eigen::aligned_allocator<pcl::PointCloud<pcl::PointXYZ>::Ptr> > &cloud_vector,
+                std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>,
+                        Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> > &cloud_vector,
                 CloudType::Type cloud_type) override;
 
         std::string get_scan_name() override;

--- a/src/file/CalibrationFileHandler.h
+++ b/src/file/CalibrationFileHandler.h
@@ -42,8 +42,7 @@ namespace file {
                         CloudType::Type cloud_type) override;
 
         void load_clouds(
-                std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>,
-                        Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> > &cloud_vector,
+                std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &cloud_vector,
                 CloudType::Type cloud_type) override;
 
         std::string get_scan_name() override;

--- a/src/file/IFileHandler.h
+++ b/src/file/IFileHandler.h
@@ -41,7 +41,7 @@ namespace file {
          * @param cloud the cloud you want to save.
          * @para cloud_type enum for the type of cloud you are saving. Affects the subfolder path.
          */
-        virtual void save_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr &cloud,
+        virtual void save_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                                 const std::string &cloud_name,
                                 CloudType::Type cloud_type) = 0;
 
@@ -53,7 +53,7 @@ namespace file {
          *
          * Example: load_cloud(cloud, "testScan", "12.pcd", CloudType::RAW)
          */
-        virtual void load_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+        virtual void load_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                 const std::string &cloud_name,
                                 CloudType::Type cloud_type) = 0;
 
@@ -68,8 +68,8 @@ namespace file {
          * @param cloud_type determines which folder to search for.
          *
          */
-        virtual void load_clouds(std::vector<pcl::PointCloud<pcl::PointXYZ>::Ptr,
-                Eigen::aligned_allocator<pcl::PointCloud<pcl::PointXYZ>::Ptr> > &cloud_vector,
+        virtual void load_clouds(std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>,
+                Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> > &cloud_vector,
                                  CloudType::Type cloud_type) = 0;
 
 

--- a/src/file/IFileHandler.h
+++ b/src/file/IFileHandler.h
@@ -68,8 +68,7 @@ namespace file {
          * @param cloud_type determines which folder to search for.
          *
          */
-        virtual void load_clouds(std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>,
-                Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> > &cloud_vector,
+        virtual void load_clouds(std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &cloud_vector,
                                  CloudType::Type cloud_type) = 0;
 
 

--- a/src/file/ScanFileHandler.cpp
+++ b/src/file/ScanFileHandler.cpp
@@ -60,7 +60,7 @@ void file::ScanFileHandler::load_cloud(std::shared_ptr<pcl::PointCloud<pcl::Poin
 
 
 void file::ScanFileHandler::load_clouds(
-        std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>, Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>>> &cloud_vector,
+        std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &cloud_vector,
         CloudType::Type cloud_type) {
     std::vector<path> cloud_paths;
     path load_path = scan_folder_path / CloudType::String(cloud_type);

--- a/src/file/ScanFileHandler.cpp
+++ b/src/file/ScanFileHandler.cpp
@@ -78,7 +78,7 @@ void file::ScanFileHandler::load_clouds(
 
     // finally we load the clouds into the cloud_vector
     for (auto &p : cloud_paths) {
-        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud(new pcl::PointCloud<pcl::PointXYZ>);
+        auto cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
         if (pcl::io::loadPCDFile<pcl::PointXYZ>(p.string(), *cloud) == -1) {
             PCL_ERROR ("Couldn't read file \n");
         }
@@ -142,8 +142,8 @@ bool file::ScanFileHandler::check_program_folder() {
         create_directory(swag_scanner_path / "calibration/default_calibration");
         std::ofstream settings(swag_scanner_path.string() + "/settings/settings.json"); // create json file
         json settings_json = {
-                {"version",     .1},
-                {"latest_scan", "none"},
+                {"version",          .1},
+                {"latest_scan",      "none"},
                 {"current_position", 0}
         };
         settings << std::setw(4) << settings_json << std::endl; // write to file

--- a/src/file/ScanFileHandler.cpp
+++ b/src/file/ScanFileHandler.cpp
@@ -40,7 +40,7 @@ file::ScanFileHandler::ScanFileHandler(const char *scan_name) {
 }
 
 
-void file::ScanFileHandler::save_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr &cloud,
+void file::ScanFileHandler::save_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                                        const std::string &cloud_name,
                                        CloudType::Type cloud_type) {
     std::cout << "saving file to ";
@@ -49,7 +49,7 @@ void file::ScanFileHandler::save_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr &clou
     pcl::io::savePCDFileASCII(out_path.string(), *cloud);
 }
 
-void file::ScanFileHandler::load_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+void file::ScanFileHandler::load_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                        const std::string &cloud_name,
                                        CloudType::Type cloud_type) {
     path open_path = scan_folder_path / CloudType::String(cloud_type) / cloud_name;
@@ -60,7 +60,7 @@ void file::ScanFileHandler::load_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud
 
 
 void file::ScanFileHandler::load_clouds(
-        std::vector<pcl::PointCloud<pcl::PointXYZ>::Ptr, Eigen::aligned_allocator<pcl::PointCloud<pcl::PointXYZ>::Ptr>> &cloud_vector,
+        std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>, Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>>> &cloud_vector,
         CloudType::Type cloud_type) {
     std::vector<path> cloud_paths;
     path load_path = scan_folder_path / CloudType::String(cloud_type);
@@ -78,7 +78,7 @@ void file::ScanFileHandler::load_clouds(
 
     // finally we load the clouds into the cloud_vector
     for (auto &p : cloud_paths) {
-        pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud(new pcl::PointCloud<pcl::PointXYZ>);
         if (pcl::io::loadPCDFile<pcl::PointXYZ>(p.string(), *cloud) == -1) {
             PCL_ERROR ("Couldn't read file \n");
         }

--- a/src/file/ScanFileHandler.h
+++ b/src/file/ScanFileHandler.h
@@ -40,16 +40,16 @@ namespace file {
          */
         ScanFileHandler(const char *scan_name);
 
-        void save_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr &cloud,
+        void save_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                         const std::string &cloud_name,
                         CloudType::Type cloud_type) override;
 
-        void load_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+        void load_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                         const std::string &cloud_name,
                         CloudType::Type cloud_type) override;
 
         void load_clouds(
-                std::vector<pcl::PointCloud<pcl::PointXYZ>::Ptr, Eigen::aligned_allocator<pcl::PointCloud<pcl::PointXYZ>::Ptr> > &cloud_vector,
+                std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>, Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> > &cloud_vector,
                 CloudType::Type cloud_type) override;
 
         std::string get_scan_name() override;

--- a/src/file/ScanFileHandler.h
+++ b/src/file/ScanFileHandler.h
@@ -49,7 +49,7 @@ namespace file {
                         CloudType::Type cloud_type) override;
 
         void load_clouds(
-                std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>, Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> > &cloud_vector,
+                std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &cloud_vector,
                 CloudType::Type cloud_type) override;
 
         std::string get_scan_name() override;

--- a/src/model/arduino/Arduino.cpp
+++ b/src/model/arduino/Arduino.cpp
@@ -3,6 +3,7 @@
 #include "IFileHandler.h"
 #include <nlohmann/json.hpp>
 #include <thread>
+#include <iostream>
 
 using json = nlohmann::json;
 using namespace std::literals::chrono_literals;
@@ -21,7 +22,7 @@ arduino::Arduino::Arduino() {
 
 
 void arduino::Arduino::rotate_by(int deg) {
-    rotate_char->write_with_response<int>(deg);
+    rotate_char->write_with_response<short>((short)deg);
 
     if (deg < 0) {
         deg += 360;

--- a/src/model/processing/Depth.cpp
+++ b/src/model/processing/Depth.cpp
@@ -5,7 +5,7 @@
 std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> depth::create_point_cloud(const std::vector<uint16_t> &depth_frame,
                                                        const camera::intrinsics intrinsics) {
     // cloud setup
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    auto cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     cloud->height = intrinsics.height;
     cloud->width = intrinsics.width;
     cloud->is_dense = true;

--- a/src/model/processing/Depth.cpp
+++ b/src/model/processing/Depth.cpp
@@ -2,10 +2,10 @@
 #include "CameraTypes.h"
 #include <librealsense2/rsutil.h>
 
-pcl::PointCloud<pcl::PointXYZ>::Ptr depth::create_point_cloud(const std::vector<uint16_t> &depth_frame,
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> depth::create_point_cloud(const std::vector<uint16_t> &depth_frame,
                                                        const camera::intrinsics intrinsics) {
     // cloud setup
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud(new pcl::PointCloud<pcl::PointXYZ>);
     cloud->height = intrinsics.height;
     cloud->width = intrinsics.width;
     cloud->is_dense = true;

--- a/src/model/processing/Depth.h
+++ b/src/model/processing/Depth.h
@@ -17,7 +17,7 @@ namespace depth {
      * @param depth_frame vector of uint16_t depth values. Not converted to meters yet.
      * @return a pointcloud.
      */
-    pcl::PointCloud<pcl::PointXYZ>::Ptr create_point_cloud(const std::vector<uint16_t> &depth_frame,
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> create_point_cloud(const std::vector<uint16_t> &depth_frame,
                                                            const camera::intrinsics intrinsics);
 }
 

--- a/src/model/processing/Filtering.cpp
+++ b/src/model/processing/Filtering.cpp
@@ -2,11 +2,11 @@
 #include <pcl/filters/crop_box.h>
 #include <pcl/filters/voxel_grid.h>
 
-pcl::PointCloud<pcl::PointXYZ>::Ptr filtering::crop_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> filtering::crop_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                           float minX, float maxX,
                                                           float minY, float maxY,
                                                           float minZ, float maxZ) {
-    pcl::PointCloud<pcl::PointXYZ>::Ptr croppedCloud(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> croppedCloud(new pcl::PointCloud<pcl::PointXYZ>);
     pcl::CropBox<pcl::PointXYZ> boxFilter;
     boxFilter.setKeepOrganized(1);
     boxFilter.setMin(Eigen::Vector4f(minX, minY, minZ, 1.0));
@@ -16,9 +16,9 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr filtering::crop_cloud(pcl::PointCloud<pcl::P
     return croppedCloud;
 }
 
-pcl::PointCloud<pcl::PointXYZ>::Ptr filtering::voxel_grid_filter(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> filtering::voxel_grid_filter(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                                  float leafSize) {
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_filtered(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud_filtered(new pcl::PointCloud<pcl::PointXYZ>);
     pcl::VoxelGrid<pcl::PointXYZ> grid;
     std::cout << "PointCloud before filtering: " << cloud->width * cloud->height
               << " data points (" << pcl::getFieldsList(*cloud) << ")." << std::endl;

--- a/src/model/processing/Filtering.cpp
+++ b/src/model/processing/Filtering.cpp
@@ -6,14 +6,14 @@ std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> filtering::crop_cloud(std::share
                                                           float minX, float maxX,
                                                           float minY, float maxY,
                                                           float minZ, float maxZ) {
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> croppedCloud(new pcl::PointCloud<pcl::PointXYZ>);
+    auto cropped_cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     pcl::CropBox<pcl::PointXYZ> boxFilter;
     boxFilter.setKeepOrganized(1);
     boxFilter.setMin(Eigen::Vector4f(minX, minY, minZ, 1.0));
     boxFilter.setMax(Eigen::Vector4f(maxX, maxY, maxZ, 1.0));
     boxFilter.setInputCloud(cloud);
-    boxFilter.filter(*croppedCloud);
-    return croppedCloud;
+    boxFilter.filter(*cropped_cloud);
+    return cropped_cloud;
 }
 
 std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> filtering::voxel_grid_filter(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,

--- a/src/model/processing/Filtering.cpp
+++ b/src/model/processing/Filtering.cpp
@@ -2,10 +2,11 @@
 #include <pcl/filters/crop_box.h>
 #include <pcl/filters/voxel_grid.h>
 
-std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> filtering::crop_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
-                                                          float minX, float maxX,
-                                                          float minY, float maxY,
-                                                          float minZ, float maxZ) {
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+filtering::crop_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+                      float minX, float maxX,
+                      float minY, float maxY,
+                      float minZ, float maxZ) {
     auto cropped_cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     pcl::CropBox<pcl::PointXYZ> boxFilter;
     boxFilter.setKeepOrganized(1);
@@ -16,9 +17,10 @@ std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> filtering::crop_cloud(std::share
     return cropped_cloud;
 }
 
-std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> filtering::voxel_grid_filter(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
-                                                                 float leafSize) {
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud_filtered(new pcl::PointCloud<pcl::PointXYZ>);
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+filtering::voxel_grid_filter(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+                             float leafSize) {
+    auto cloud_filtered = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     pcl::VoxelGrid<pcl::PointXYZ> grid;
     std::cout << "PointCloud before filtering: " << cloud->width * cloud->height
               << " data points (" << pcl::getFieldsList(*cloud) << ")." << std::endl;

--- a/src/model/processing/Filtering.h
+++ b/src/model/processing/Filtering.h
@@ -15,7 +15,7 @@ namespace filtering {
      * @param cloud cloud you want to crop.
      * @return the cropped cloud.
      */
-    pcl::PointCloud<pcl::PointXYZ>::Ptr crop_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> crop_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                    float minX, float maxX,
                                                    float minY, float maxY,
                                                    float minZ, float maxZ);
@@ -26,7 +26,7 @@ namespace filtering {
      * @param leafSize size of leaf.
      * @return the filtered cloud.
      */
-    pcl::PointCloud<pcl::PointXYZ>::Ptr voxel_grid_filter(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> voxel_grid_filter(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                           float leafSize);
 }
 

--- a/src/model/processing/Model.cpp
+++ b/src/model/processing/Model.cpp
@@ -31,7 +31,7 @@ pcl::PointCloud<pcl::Normal>::Ptr model::Model::estimate_normal_cloud(
 
     auto normals = std::make_shared<pcl::PointCloud<pcl::Normal>>();
     pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> ne;
-    pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>());
+    auto tree = std::make_shared<pcl::search::KdTree<pcl::PointXYZ>>();
     ne.setSearchMethod(tree);
     ne.setRadiusSearch(0.03);
 
@@ -45,11 +45,11 @@ pcl::PointCloud<pcl::Normal>::Ptr model::Model::estimate_normal_cloud(
 void model::Model::compute_local_features(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                           pcl::PointCloud<pcl::Normal>::Ptr normalCloud,
                                           pcl::PointCloud<pcl::FPFHSignature33>::Ptr features) {
-    pcl::search::KdTree<pcl::PointXYZ>::Ptr searchMethod(new pcl::search::KdTree<pcl::PointXYZ>);
+    auto tree = std::make_shared<pcl::search::KdTree<pcl::PointXYZ>>();
     pcl::FPFHEstimation<pcl::PointXYZ, pcl::Normal, pcl::FPFHSignature33> fpfh_est;
     fpfh_est.setInputCloud(cloud);
     fpfh_est.setInputNormals(normalCloud);
-    fpfh_est.setSearchMethod(searchMethod);
+    fpfh_est.setSearchMethod(tree);
     fpfh_est.setRadiusSearch(.05);
     fpfh_est.compute(*features);
 }

--- a/src/model/processing/Model.cpp
+++ b/src/model/processing/Model.cpp
@@ -18,8 +18,9 @@
 model::Model::Model() {}
 
 
-std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> model::Model::create_point_cloud(const std::vector<uint16_t> &depth_frame,
-                                                                     const camera::intrinsics intrinsics) {
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+model::Model::create_point_cloud(const std::vector<uint16_t> &depth_frame,
+                                 const camera::intrinsics intrinsics) {
 
     std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> point_cloud = depth::create_point_cloud(depth_frame, intrinsics);
     return point_cloud;
@@ -53,19 +54,22 @@ void model::Model::compute_local_features(std::shared_ptr<pcl::PointCloud<pcl::P
     fpfh_est.compute(*features);
 }
 
-std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> model::Model::crop_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
-                                                             float minX, float maxX,
-                                                             float minY, float maxY,
-                                                             float minZ, float maxZ) {
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+model::Model::crop_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+                         float minX, float maxX,
+                         float minY, float maxY,
+                         float minZ, float maxZ) {
     return filtering::crop_cloud(cloud, minX, maxX, minY, maxY, minZ, maxZ);
 }
 
-std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> model::Model::voxel_grid_filter(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
-                                                                    float leafSize) {
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+model::Model::voxel_grid_filter(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+                                float leafSize) {
     return filtering::voxel_grid_filter(cloud, leafSize);
 }
 
-std::vector<equations::Plane> model::Model::get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
+std::vector<equations::Plane>
+model::Model::get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
     return segmentation::get_calibration_planes_coefs(cloud);
 }
 
@@ -73,7 +77,8 @@ std::vector<float> model::Model::get_plane_coefs(std::shared_ptr<pcl::PointCloud
     return segmentation::get_plane_coefs(cloud);
 }
 
-std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> model::Model::remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn) {
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+model::Model::remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn) {
     return segmentation::remove_plane(cloudIn);
 }
 
@@ -101,27 +106,29 @@ equations::Point model::Model::calculate_center_pt(equations::Normal axis_dir,
     return center;
 }
 
-pcl::PointCloud<pcl::PointXYZ> model::Model::rotate_cloud_about_line(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
-                                                                          std::vector<float> line_point,
-                                                                          std::vector<float> line_direction,
-                                                                          float theta) {
+pcl::PointCloud<pcl::PointXYZ>
+model::Model::rotate_cloud_about_line(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+                                      std::vector<float> line_point,
+                                      std::vector<float> line_direction,
+                                      float theta) {
     pcl::PointCloud<pcl::PointXYZ> transformed;
 
     transformed.resize(cloud->size());
 
     for (int i = 0; i < cloud->size(); i++) {
         transformed.points[i] = algos::rotate_point_about_line(cloud->points[i],
-                                                                line_point,
-                                                                line_direction,
-                                                                theta);
+                                                               line_point,
+                                                               line_direction,
+                                                               theta);
     }
     return transformed;
 }
 
-std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> model::Model::transform_cloud_to_world(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
-                                                                           pcl::PointXYZ center,
-                                                                           equations::Normal ground_normal) {
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> result(new pcl::PointCloud<pcl::PointXYZ>);
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+model::Model::transform_cloud_to_world(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+                                       pcl::PointXYZ center,
+                                       equations::Normal ground_normal) {
+    auto result = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     Eigen::Matrix4f transform = algos::calc_transform_to_world_matrix(center, ground_normal);
     pcl::transformPointCloud(*cloud, *result, transform);
     return result;
@@ -142,9 +149,8 @@ void model::Model::sac_align_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::Po
 
     pcl::PointCloud<pcl::Normal>::Ptr cloudInNormal = estimate_normal_cloud(cloudIn);
     pcl::PointCloud<pcl::Normal>::Ptr cloudTargetNormal = estimate_normal_cloud(cloudTarget);
-    pcl::PointCloud<pcl::FPFHSignature33>::Ptr cloudInFeatures(new pcl::PointCloud<pcl::FPFHSignature33>);
-    pcl::PointCloud<pcl::FPFHSignature33>::Ptr cloudTargetFeatures(new pcl::PointCloud<pcl::FPFHSignature33>);
-
+    auto cloudInFeatures = std::make_shared<pcl::PointCloud<pcl::FPFHSignature33>>();
+    auto cloudTargetFeatures = std::make_shared<pcl::PointCloud<pcl::FPFHSignature33>>();
     registration::sac_align_pair_clouds(cloudIn, cloudTarget, cloudInFeatures, cloudTargetFeatures,
                                         cloudAligned, transformation);
 }

--- a/src/model/processing/Model.cpp
+++ b/src/model/processing/Model.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> model::Model::create_point_cloud
 pcl::PointCloud<pcl::Normal>::Ptr model::Model::estimate_normal_cloud(
         std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
 
-    pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
+    auto normals = std::make_shared<pcl::PointCloud<pcl::Normal>>();
     pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> ne;
     pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>());
     ne.setSearchMethod(tree);
@@ -101,16 +101,16 @@ equations::Point model::Model::calculate_center_pt(equations::Normal axis_dir,
     return center;
 }
 
-std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> model::Model::rotate_cloud_about_line(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+pcl::PointCloud<pcl::PointXYZ> model::Model::rotate_cloud_about_line(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                                           std::vector<float> line_point,
                                                                           std::vector<float> line_direction,
                                                                           float theta) {
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transformed(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::PointCloud<pcl::PointXYZ> transformed;
 
-    transformed->resize(cloud->size());
+    transformed.resize(cloud->size());
 
     for (int i = 0; i < cloud->size(); i++) {
-        transformed->points[i] = algos::rotate_point_about_line(cloud->points[i],
+        transformed.points[i] = algos::rotate_point_about_line(cloud->points[i],
                                                                 line_point,
                                                                 line_direction,
                                                                 theta);

--- a/src/model/processing/Model.cpp
+++ b/src/model/processing/Model.cpp
@@ -18,15 +18,15 @@
 model::Model::Model() {}
 
 
-pcl::PointCloud<pcl::PointXYZ>::Ptr model::Model::create_point_cloud(const std::vector<uint16_t> &depth_frame,
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> model::Model::create_point_cloud(const std::vector<uint16_t> &depth_frame,
                                                                      const camera::intrinsics intrinsics) {
 
-    pcl::PointCloud<pcl::PointXYZ>::Ptr point_cloud = depth::create_point_cloud(depth_frame, intrinsics);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> point_cloud = depth::create_point_cloud(depth_frame, intrinsics);
     return point_cloud;
 }
 
 pcl::PointCloud<pcl::Normal>::Ptr model::Model::estimate_normal_cloud(
-        pcl::PointCloud<pcl::PointXYZ>::Ptr cloud) {
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
 
     pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
     pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> ne;
@@ -41,7 +41,7 @@ pcl::PointCloud<pcl::Normal>::Ptr model::Model::estimate_normal_cloud(
     return normals;
 }
 
-void model::Model::compute_local_features(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+void model::Model::compute_local_features(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                           pcl::PointCloud<pcl::Normal>::Ptr normalCloud,
                                           pcl::PointCloud<pcl::FPFHSignature33>::Ptr features) {
     pcl::search::KdTree<pcl::PointXYZ>::Ptr searchMethod(new pcl::search::KdTree<pcl::PointXYZ>);
@@ -53,27 +53,27 @@ void model::Model::compute_local_features(pcl::PointCloud<pcl::PointXYZ>::Ptr cl
     fpfh_est.compute(*features);
 }
 
-pcl::PointCloud<pcl::PointXYZ>::Ptr model::Model::crop_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> model::Model::crop_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                              float minX, float maxX,
                                                              float minY, float maxY,
                                                              float minZ, float maxZ) {
     return filtering::crop_cloud(cloud, minX, maxX, minY, maxY, minZ, maxZ);
 }
 
-pcl::PointCloud<pcl::PointXYZ>::Ptr model::Model::voxel_grid_filter(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> model::Model::voxel_grid_filter(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                                     float leafSize) {
     return filtering::voxel_grid_filter(cloud, leafSize);
 }
 
-std::vector<equations::Plane> model::Model::get_calibration_planes_coefs(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud) {
+std::vector<equations::Plane> model::Model::get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
     return segmentation::get_calibration_planes_coefs(cloud);
 }
 
-std::vector<float> model::Model::get_plane_coefs(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud) {
+std::vector<float> model::Model::get_plane_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
     return segmentation::get_plane_coefs(cloud);
 }
 
-pcl::PointCloud<pcl::PointXYZ>::Ptr model::Model::remove_plane(pcl::PointCloud<pcl::PointXYZ>::Ptr &cloudIn) {
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> model::Model::remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn) {
     return segmentation::remove_plane(cloudIn);
 }
 
@@ -101,11 +101,11 @@ equations::Point model::Model::calculate_center_pt(equations::Normal axis_dir,
     return center;
 }
 
-pcl::PointCloud<pcl::PointXYZ>::Ptr model::Model::rotate_cloud_about_line(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> model::Model::rotate_cloud_about_line(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                                           std::vector<float> line_point,
                                                                           std::vector<float> line_direction,
                                                                           float theta) {
-    pcl::PointCloud<pcl::PointXYZ>::Ptr transformed(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transformed(new pcl::PointCloud<pcl::PointXYZ>);
 
     transformed->resize(cloud->size());
 
@@ -118,26 +118,26 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr model::Model::rotate_cloud_about_line(pcl::P
     return transformed;
 }
 
-pcl::PointCloud<pcl::PointXYZ>::Ptr model::Model::transform_cloud_to_world(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> model::Model::transform_cloud_to_world(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                                            pcl::PointXYZ center,
                                                                            equations::Normal ground_normal) {
-    pcl::PointCloud<pcl::PointXYZ>::Ptr result(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> result(new pcl::PointCloud<pcl::PointXYZ>);
     Eigen::Matrix4f transform = algos::calc_transform_to_world_matrix(center, ground_normal);
     pcl::transformPointCloud(*cloud, *result, transform);
     return result;
 }
 
-Eigen::Matrix4f model::Model::icp_register_pair_clouds(pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn,
-                                                       pcl::PointCloud<pcl::PointXYZ>::Ptr cloudOut,
-                                                       pcl::PointCloud<pcl::PointXYZ>::Ptr transformedCloud) {
+Eigen::Matrix4f model::Model::icp_register_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
+                                                       std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOut,
+                                                       std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transformedCloud) {
     return registration::icp_register_pair_clouds(cloudIn, cloudOut, transformedCloud);
 
 }
 
 
-void model::Model::sac_align_pair_clouds(pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn,
-                                         pcl::PointCloud<pcl::PointXYZ>::Ptr cloudTarget,
-                                         pcl::PointCloud<pcl::PointXYZ>::Ptr cloudAligned,
+void model::Model::sac_align_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
+                                         std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudTarget,
+                                         std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudAligned,
                                          Eigen::Matrix4f &transformation) {
 
     pcl::PointCloud<pcl::Normal>::Ptr cloudInNormal = estimate_normal_cloud(cloudIn);

--- a/src/model/processing/Model.h
+++ b/src/model/processing/Model.h
@@ -125,7 +125,7 @@ namespace model {
          * @param theta angle in radians you want to rotate.
          * @return the rotated cloud.
          */
-        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> rotate_cloud_about_line(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+        pcl::PointCloud<pcl::PointXYZ> rotate_cloud_about_line(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                                     std::vector<float> line_point,
                                                                     std::vector<float> line_direction,
                                                                     float theta);

--- a/src/model/processing/Model.h
+++ b/src/model/processing/Model.h
@@ -37,7 +37,7 @@ namespace model {
         * Create a new PointCloudXYZ using the instance variable depth_frame.
         * @return a boost pointer to the new pointcloud.
         */
-        pcl::PointCloud<pcl::PointXYZ>::Ptr create_point_cloud(const std::vector<uint16_t> &depth_frame,
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> create_point_cloud(const std::vector<uint16_t> &depth_frame,
                                                                const camera::intrinsics intrinsics);
 
         /**
@@ -45,7 +45,7 @@ namespace model {
          * @return a normal cloud.
          */
         pcl::PointCloud<pcl::Normal>::Ptr estimate_normal_cloud(
-                pcl::PointCloud<pcl::PointXYZ>::Ptr point_cloud);
+                std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> point_cloud);
 
         /**
          * Given a cloud and its normal, calculate the features.
@@ -53,7 +53,7 @@ namespace model {
          * @param normalCloud normlas of cloud.
          * @param features features.
          */
-        void compute_local_features(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+        void compute_local_features(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                     pcl::PointCloud<pcl::Normal>::Ptr normalCloud,
                                     pcl::PointCloud<pcl::FPFHSignature33>::Ptr features);
 
@@ -63,7 +63,7 @@ namespace model {
          * @param croppedCloud the cropped cloud.
          * @return the cropped cloud.
          */
-        pcl::PointCloud<pcl::PointXYZ>::Ptr crop_cloud(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> crop_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                        float minX, float maxX,
                                                        float minY, float maxY,
                                                        float minZ, float maxZ);
@@ -74,7 +74,7 @@ namespace model {
          * @param leafSize size of leaf.
          * @return the downsampled cloud.
          */
-        pcl::PointCloud<pcl::PointXYZ>::Ptr voxel_grid_filter(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> voxel_grid_filter(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                               float leafSize = .01);
 
         /**
@@ -82,21 +82,21 @@ namespace model {
          * @param cloud calibration cloud.
          * @return vector of upright and ground plane equations.
          */
-        std::vector<equations::Plane> get_calibration_planes_coefs(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud);
+        std::vector<equations::Plane> get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud);
 
         /**
          * Get the coefficients of the base plane of the given cloud.
          * @param cloud input cloud.
          * @return vector of size 4 of the plane coefficients.
          */
-        std::vector<float> get_plane_coefs(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud);
+        std::vector<float> get_plane_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud);
 
         /**
          * Remove scanning bed plane from the cloud.
          * @param cloudIn cloud you want to remove the plane from.
          * @return cloud with the remove plane
          */
-        pcl::PointCloud<pcl::PointXYZ>::Ptr remove_plane(pcl::PointCloud<pcl::PointXYZ>::Ptr &cloudIn);
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn);
 
         /**
          * Given a vector of ground planes, calculate the axis direction by taking the
@@ -125,7 +125,7 @@ namespace model {
          * @param theta angle in radians you want to rotate.
          * @return the rotated cloud.
          */
-        pcl::PointCloud<pcl::PointXYZ>::Ptr rotate_cloud_about_line(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> rotate_cloud_about_line(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                                     std::vector<float> line_point,
                                                                     std::vector<float> line_direction,
                                                                     float theta);
@@ -139,7 +139,7 @@ namespace model {
          * @param ground_normal direction vector of ground.
          * @return
          */
-        pcl::PointCloud<pcl::PointXYZ>::Ptr transform_cloud_to_world(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transform_cloud_to_world(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
                                                                      pcl::PointXYZ center,
                                                                      equations::Normal ground_normal);
 
@@ -150,9 +150,9 @@ namespace model {
          * @param transformedCloud the final transformed cloud.
          * @returns a transformation matrix from the source to target cloud.
          */
-        Eigen::Matrix4f icp_register_pair_clouds(pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn,
-                                                 pcl::PointCloud<pcl::PointXYZ>::Ptr cloudOut,
-                                                 pcl::PointCloud<pcl::PointXYZ>::Ptr transformedCloud);
+        Eigen::Matrix4f icp_register_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
+                                                 std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOut,
+                                                 std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transformedCloud);
 
 
         /**
@@ -161,9 +161,9 @@ namespace model {
          * @param cloudTarget target cloud.
          * @param cloudAligned the aligned cloud.
          */
-        void sac_align_pair_clouds(pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn,
-                                   pcl::PointCloud<pcl::PointXYZ>::Ptr cloudTarget,
-                                   pcl::PointCloud<pcl::PointXYZ>::Ptr cloudAligned,
+        void sac_align_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
+                                   std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudTarget,
+                                   std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudAligned,
                                    Eigen::Matrix4f &transformation);
 
 

--- a/src/model/processing/Registration.cpp
+++ b/src/model/processing/Registration.cpp
@@ -2,9 +2,9 @@
 #include <pcl/registration/icp.h>
 #include <pcl/registration/ia_ransac.h>
 
-Eigen::Matrix4f registration::icp_register_pair_clouds(pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn,
-                                                pcl::PointCloud<pcl::PointXYZ>::Ptr cloudOut,
-                                                pcl::PointCloud<pcl::PointXYZ>::Ptr transformedCloud) {
+Eigen::Matrix4f registration::icp_register_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
+                                                std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOut,
+                                                std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transformedCloud) {
     pcl::IterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ> icp;
     icp.setInputSource(cloudIn);
     icp.setInputTarget(cloudOut);
@@ -21,11 +21,11 @@ Eigen::Matrix4f registration::icp_register_pair_clouds(pcl::PointCloud<pcl::Poin
     return icp.getFinalTransformation();
 }
 
-void registration::sac_align_pair_clouds(pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn,
-                                  pcl::PointCloud<pcl::PointXYZ>::Ptr cloudTarget,
+void registration::sac_align_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
+                                  std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudTarget,
                                   pcl::PointCloud<pcl::FPFHSignature33>::Ptr cloudInFeatures,
                                   pcl::PointCloud<pcl::FPFHSignature33>::Ptr cloudOutFeatures,
-                                  pcl::PointCloud<pcl::PointXYZ>::Ptr cloudAligned,
+                                  std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudAligned,
                                   Eigen::Matrix4f &transformation) {
     pcl::SampleConsensusInitialAlignment<pcl::PointXYZ, pcl::PointXYZ, pcl::FPFHSignature33> reg;
     reg.setMinSampleDistance(0.05f);

--- a/src/model/processing/Registration.h
+++ b/src/model/processing/Registration.h
@@ -13,9 +13,9 @@ namespace registration {
      * @param transformedCloud empty cloud used as output.
      * @return transformation matrix source -> target.
      */
-    Eigen::Matrix4f icp_register_pair_clouds(pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn,
-                                             pcl::PointCloud<pcl::PointXYZ>::Ptr cloudOut,
-                                             pcl::PointCloud<pcl::PointXYZ>::Ptr transformedCloud);
+    Eigen::Matrix4f icp_register_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
+                                             std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOut,
+                                             std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transformedCloud);
 
     /**
      * Use SAC model to align cloud to target.
@@ -26,11 +26,11 @@ namespace registration {
      * @param cloudAligned output cloud source -> target.
      * @param transformation output transformation.
      */
-    void sac_align_pair_clouds(pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn,
-                                      pcl::PointCloud<pcl::PointXYZ>::Ptr cloudTarget,
+    void sac_align_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
+                                      std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudTarget,
                                       pcl::PointCloud<pcl::FPFHSignature33>::Ptr cloudInFeatures,
                                       pcl::PointCloud<pcl::FPFHSignature33>::Ptr cloudOutFeatures,
-                                      pcl::PointCloud<pcl::PointXYZ>::Ptr cloudAligned,
+                                      std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudAligned,
                                       Eigen::Matrix4f &transformation);
 }
 

--- a/src/model/processing/Segmentation.cpp
+++ b/src/model/processing/Segmentation.cpp
@@ -7,11 +7,12 @@
 #include <pcl/filters/extract_indices.h>
 
 
-std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> segmentation::remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn) {
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+segmentation::remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn) {
     pcl::ModelCoefficients::Ptr coefficients(new pcl::ModelCoefficients);
     pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudInliers(new pcl::PointCloud<pcl::PointXYZ>);
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOutliers(new pcl::PointCloud<pcl::PointXYZ>);
+    auto cloud_inliers = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto cloud_outliers = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     // Create the segmentation object
     pcl::SACSegmentation<pcl::PointXYZ> seg;
     coefficients->values.resize(4);
@@ -40,23 +41,24 @@ std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> segmentation::remove_plane(std::
     extract.setInputCloud(cloudIn);
     extract.setIndices(inliers);
     extract.setNegative(false);            // Extract the inliers
-    extract.filter(*cloudInliers);        // cloud_inliers contains the plane
+    extract.filter(*cloud_inliers);        // cloud_inliers contains the plane
 
     // Extract outliers
     extract.setNegative(true);                // Extract the outliers
-    extract.filter(*cloudOutliers);        // cloud_outliers contains everything but the plane
-    return cloudOutliers;
+    extract.filter(*cloud_outliers);        // cloud_outliers contains everything but the plane
+    return cloud_outliers;
 }
 
-std::vector<equations::Plane> segmentation::get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
+std::vector<equations::Plane>
+segmentation::get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
     std::vector<equations::Plane> planes;
     // Create the segmentation object for the planar model and set all the parameters
     pcl::SACSegmentation<pcl::PointXYZ> seg;
     pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
     pcl::ModelCoefficients::Ptr coefficients(new pcl::ModelCoefficients);
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> temp_cloud(new pcl::PointCloud<pcl::PointXYZ>());
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud_plane(new pcl::PointCloud<pcl::PointXYZ>());
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud_f(new pcl::PointCloud<pcl::PointXYZ>());
+    auto temp_cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto cloud_plane = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto cloud_f = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     *temp_cloud = *cloud;
 
     seg.setOptimizeCoefficients(true);

--- a/src/model/processing/Segmentation.cpp
+++ b/src/model/processing/Segmentation.cpp
@@ -7,11 +7,11 @@
 #include <pcl/filters/extract_indices.h>
 
 
-pcl::PointCloud<pcl::PointXYZ>::Ptr segmentation::remove_plane(pcl::PointCloud<pcl::PointXYZ>::Ptr &cloudIn) {
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> segmentation::remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn) {
     pcl::ModelCoefficients::Ptr coefficients(new pcl::ModelCoefficients);
     pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudInliers(new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudOutliers(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudInliers(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOutliers(new pcl::PointCloud<pcl::PointXYZ>);
     // Create the segmentation object
     pcl::SACSegmentation<pcl::PointXYZ> seg;
     coefficients->values.resize(4);
@@ -48,15 +48,15 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr segmentation::remove_plane(pcl::PointCloud<p
     return cloudOutliers;
 }
 
-std::vector<equations::Plane> segmentation::get_calibration_planes_coefs(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud) {
+std::vector<equations::Plane> segmentation::get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
     std::vector<equations::Plane> planes;
     // Create the segmentation object for the planar model and set all the parameters
     pcl::SACSegmentation<pcl::PointXYZ> seg;
     pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
     pcl::ModelCoefficients::Ptr coefficients(new pcl::ModelCoefficients);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr temp_cloud(new pcl::PointCloud<pcl::PointXYZ>());
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_plane(new pcl::PointCloud<pcl::PointXYZ>());
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_f(new pcl::PointCloud<pcl::PointXYZ>());
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> temp_cloud(new pcl::PointCloud<pcl::PointXYZ>());
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud_plane(new pcl::PointCloud<pcl::PointXYZ>());
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud_f(new pcl::PointCloud<pcl::PointXYZ>());
     *temp_cloud = *cloud;
 
     seg.setOptimizeCoefficients(true);
@@ -101,7 +101,7 @@ std::vector<equations::Plane> segmentation::get_calibration_planes_coefs(pcl::Po
     return planes;
 }
 
-std::vector<float> segmentation::get_plane_coefs(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud) {
+std::vector<float> segmentation::get_plane_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
     pcl::ModelCoefficients::Ptr coefficients(new pcl::ModelCoefficients);
     pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
     pcl::SACSegmentation<pcl::PointXYZ> seg;

--- a/src/model/processing/Segmentation.cpp
+++ b/src/model/processing/Segmentation.cpp
@@ -9,13 +9,13 @@
 
 std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
 segmentation::remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn) {
-    pcl::ModelCoefficients::Ptr coefficients(new pcl::ModelCoefficients);
-    pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
+    pcl::ModelCoefficients coefficients;
+    auto inliers = std::make_shared<pcl::PointIndices>();
     auto cloud_inliers = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     auto cloud_outliers = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     // Create the segmentation object
     pcl::SACSegmentation<pcl::PointXYZ> seg;
-    coefficients->values.resize(4);
+    coefficients.values.resize(4);
     // Optional
     seg.setOptimizeCoefficients(true);
     // Mandatory
@@ -24,16 +24,16 @@ segmentation::remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &clou
     seg.setDistanceThreshold(0.005);
 
     seg.setInputCloud(cloudIn);
-    seg.segment(*inliers, *coefficients);
+    seg.segment(*inliers, coefficients);
 
     if (inliers->indices.empty()) {
         PCL_ERROR ("Could not estimate a planar model for the given dataset.");
     }
 
-    std::cerr << "Model coefficients: " << coefficients->values[0] << " "
-              << coefficients->values[1] << " "
-              << coefficients->values[2] << " "
-              << coefficients->values[3] << std::endl;
+    std::cerr << "Model coefficients: " << coefficients.values[0] << " "
+              << coefficients.values[1] << " "
+              << coefficients.values[2] << " "
+              << coefficients.values[3] << std::endl;
 
 
     // Extract inliers
@@ -54,8 +54,8 @@ segmentation::get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::
     std::vector<equations::Plane> planes;
     // Create the segmentation object for the planar model and set all the parameters
     pcl::SACSegmentation<pcl::PointXYZ> seg;
-    pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
-    pcl::ModelCoefficients::Ptr coefficients(new pcl::ModelCoefficients);
+    auto inliers = std::make_shared<pcl::PointIndices>();
+    auto coefficients = std::make_shared<pcl::ModelCoefficients>();
     auto temp_cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     auto cloud_plane = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     auto cloud_f = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
@@ -104,21 +104,22 @@ segmentation::get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::
 }
 
 std::vector<float> segmentation::get_plane_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
-    pcl::ModelCoefficients::Ptr coefficients(new pcl::ModelCoefficients);
-    pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
+    pcl::PointIndices inliers;
+    pcl::ModelCoefficients coefficients;
+
     pcl::SACSegmentation<pcl::PointXYZ> seg;
-    coefficients->values.resize(4);
+    coefficients.values.resize(4);
     seg.setOptimizeCoefficients(true);
     seg.setModelType(pcl::SACMODEL_PLANE);
     seg.setMethodType(pcl::SAC_RANSAC);
     seg.setDistanceThreshold(0.005);
     seg.setInputCloud(cloud);
-    seg.segment(*inliers, *coefficients);
+    seg.segment(inliers, coefficients);
 
-    std::cout << "Model coefficients: " << coefficients->values[0] << " "
-              << coefficients->values[1] << " "
-              << coefficients->values[2] << " "
-              << coefficients->values[3] << std::endl;
+    std::cout << "Model coefficients: " << coefficients.values[0] << " "
+              << coefficients.values[1] << " "
+              << coefficients.values[2] << " "
+              << coefficients.values[3] << std::endl;
 
-    return coefficients->values;
+    return coefficients.values;
 }

--- a/src/model/processing/Segmentation.h
+++ b/src/model/processing/Segmentation.h
@@ -16,7 +16,7 @@ namespace segmentation {
      * @param cloudIn cloud with plane.
      * @return cloud without plane.
      */
-    pcl::PointCloud<pcl::PointXYZ>::Ptr remove_plane(pcl::PointCloud<pcl::PointXYZ>::Ptr &cloudIn);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn);
 
 
     /**
@@ -26,14 +26,14 @@ namespace segmentation {
      * @return a vector of coefficients for the two planes.
      * First element in vector is upright plane. Second element is ground plane.
      */
-    std::vector<equations::Plane> get_calibration_planes_coefs(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud);
+    std::vector<equations::Plane> get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud);
 
     /**
      * Get the plane coefficients of the base of the given cloud.
      * @param cloud input cloud.
      * @return coefficients vector of size 4 of the cloud.
      */
-    std::vector<float> get_plane_coefs(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud);
+    std::vector<float> get_plane_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud);
 }
 
 #endif //SWAG_SCANNER_SEGMENTATION_H

--- a/src/view/Visualizer.cpp
+++ b/src/view/Visualizer.cpp
@@ -11,83 +11,83 @@ visual::Visualizer::Visualizer() {}
 
 void visual::Visualizer::simpleVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud) {
 
-    pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("3D Viewer"));
-    viewer->setBackgroundColor(0, 0, 0);
-    viewer->addPointCloud<pcl::PointXYZ>(cloud, "sample cloud");
-    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 1, "sample cloud");
-    viewer->addCoordinateSystem(1.0);
-    viewer->initCameraParameters();
-    while (!viewer->wasStopped()) {
-        viewer->spinOnce(100);
+    pcl::visualization::PCLVisualizer viewer("3D viewer");
+    viewer.setBackgroundColor(0, 0, 0);
+    viewer.addPointCloud<pcl::PointXYZ>(cloud, "sample cloud");
+    viewer.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 1, "sample cloud");
+    viewer.addCoordinateSystem(1.0);
+    viewer.initCameraParameters();
+    while (!viewer.wasStopped()) {
+        viewer.spinOnce(100);
         std::this_thread::sleep_for(100ms);
     }
 }
 
 void visual::Visualizer::simpleVis(std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr> clouds) {
-    pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("3D Viewer"));
+    pcl::visualization::PCLVisualizer viewer("3D viewer");
 
     int r = 255;
     int delta = clouds.size() / 10;
 
-    viewer->addPointCloud<pcl::PointXYZ>(clouds[0], std::to_string(0));
+    viewer.addPointCloud<pcl::PointXYZ>(clouds[0], std::to_string(0));
     for (int i = 1; i < clouds.size(); i++) {
         pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> color_handler(clouds[i], r, 0, 0);
-        viewer->addPointCloud<pcl::PointXYZ>(clouds[i], color_handler, std::to_string(i));
+        viewer.addPointCloud<pcl::PointXYZ>(clouds[i], color_handler, std::to_string(i));
         r -= delta; // doesn't scale nicely but that's okay for now'
     }
 
 //    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 1, "sample cloud");
-    viewer->setBackgroundColor(0, 0, 0);
-    viewer->addCoordinateSystem(1.0);
-    viewer->initCameraParameters();
-    while (!viewer->wasStopped()) {
-        viewer->spinOnce(100);
+    viewer.setBackgroundColor(0, 0, 0);
+    viewer.addCoordinateSystem(1.0);
+    viewer.initCameraParameters();
+    while (!viewer.wasStopped()) {
+        viewer.spinOnce(100);
         std::this_thread::sleep_for(100ms);
     }
 }
 
 void visual::Visualizer::simpleVisColor(std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr> clouds) {
-    pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("3D Viewer"));
+    pcl::visualization::PCLVisualizer viewer("3D viewer");
 
     int b = 255;
     int delta = clouds.size() / 10;
 
     pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> handler(clouds[0], 0, 255, 0);
-    viewer->addPointCloud<pcl::PointXYZ>(clouds[0], handler, std::to_string(0));
-    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 9, "0");
+    viewer.addPointCloud<pcl::PointXYZ>(clouds[0], handler, std::to_string(0));
+    viewer.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 9, "0");
     for (int i = 1; i < clouds.size(); i++) {
         pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> color_handler(clouds[i], 0, 0, b);
-        viewer->addPointCloud<pcl::PointXYZ>(clouds[i], color_handler, std::to_string(i));
-        viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 9, std::to_string(i));
+        viewer.addPointCloud<pcl::PointXYZ>(clouds[i], color_handler, std::to_string(i));
+        viewer.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 9, std::to_string(i));
         b -= delta; // doesn't scale nicely but that's okay for now'
     }
 
 //    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 1, "sample cloud");
-    viewer->setBackgroundColor(255, 255, 255);
-    viewer->addCoordinateSystem(1.0);
-    viewer->initCameraParameters();
-    while (!viewer->wasStopped()) {
-        viewer->spinOnce(100);
+    viewer.setBackgroundColor(255, 255, 255);
+    viewer.addCoordinateSystem(1.0);
+    viewer.initCameraParameters();
+    while (!viewer.wasStopped()) {
+        viewer.spinOnce(100);
         std::this_thread::sleep_for(100ms);
     }
 }
 
 void visual::Visualizer::ptVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud, pcl::PointXYZ pt) {
-    pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("3D Viewer"));
+    pcl::visualization::PCLVisualizer viewer("3D viewer");
     auto point = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     point->push_back(pt);
 
-    viewer->setBackgroundColor(0, 0, 0);
-    viewer->addCoordinateSystem(1.0);
-    viewer->initCameraParameters();
+    viewer.setBackgroundColor(0, 0, 0);
+    viewer.addCoordinateSystem(1.0);
+    viewer.initCameraParameters();
 
     pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> color_handler(point, 255, 0, 0);
 
-    viewer->addPointCloud<pcl::PointXYZ>(cloud, "cloud");
-    viewer->addPointCloud<pcl::PointXYZ>(point, color_handler, "point");
-    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 4, "point");
-    while (!viewer->wasStopped()) {
-        viewer->spinOnce(100);
+    viewer.addPointCloud<pcl::PointXYZ>(cloud, "cloud");
+    viewer.addPointCloud<pcl::PointXYZ>(point, color_handler, "point");
+    viewer.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 4, "point");
+    while (!viewer.wasStopped()) {
+        viewer.spinOnce(100);
         std::this_thread::sleep_for(100ms);
     }
 }
@@ -95,45 +95,45 @@ void visual::Visualizer::ptVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud, p
 
 void visual::Visualizer::normalsVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud,
                                     pcl::PointCloud<pcl::Normal>::ConstPtr normals) {
-    pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("3D Viewer"));
-    viewer->setBackgroundColor(0, 0, 0);
+    pcl::visualization::PCLVisualizer viewer("3D viewer");
+    viewer.setBackgroundColor(0, 0, 0);
     pcl::visualization::PointCloudGeometryHandlerXYZ<pcl::PointXYZ> rgb(cloud);
-    viewer->addPointCloud<pcl::PointXYZ>(cloud, rgb, "sample cloud");
-    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 3, "sample cloud");
-    viewer->addPointCloudNormals<pcl::PointXYZ, pcl::Normal>(cloud, normals, 10, 0.05, "normals");
-    viewer->addCoordinateSystem(1.0);
-    viewer->initCameraParameters();
-    while (!viewer->wasStopped()) {
-        viewer->spinOnce(100);
+    viewer.addPointCloud<pcl::PointXYZ>(cloud, rgb, "sample cloud");
+    viewer.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 3, "sample cloud");
+    viewer.addPointCloudNormals<pcl::PointXYZ, pcl::Normal>(cloud, normals, 10, 0.05, "normals");
+    viewer.addCoordinateSystem(1.0);
+    viewer.initCameraParameters();
+    while (!viewer.wasStopped()) {
+        viewer.spinOnce(100);
         std::this_thread::sleep_for(100ms);
     }
 }
 
 void visual::Visualizer::compareVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud1,
                                     pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud2) {
-    pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("3D Viewer"));
-    viewer->initCameraParameters();
+    pcl::visualization::PCLVisualizer viewer("3D viewer");
+    viewer.initCameraParameters();
 
     int v1(0);
-    viewer->createViewPort(0.0, 0.0, 0.5, 1.0, v1);
-    viewer->setBackgroundColor(0, 0, 0, v1);
-    viewer->addText("unfiltered cloud", 10, 10, "v1 text", v1);
+    viewer.createViewPort(0.0, 0.0, 0.5, 1.0, v1);
+    viewer.setBackgroundColor(0, 0, 0, v1);
+    viewer.addText("unfiltered cloud", 10, 10, "v1 text", v1);
     pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> handler1(cloud1, 255, 255, 255);
-    viewer->addPointCloud<pcl::PointXYZ>(cloud1, handler1, "sample cloud1", v1);
+    viewer.addPointCloud<pcl::PointXYZ>(cloud1, handler1, "sample cloud1", v1);
 
     int v2(0);
-    viewer->createViewPort(0.5, 0.0, 1.0, 1.0, v2);
-    viewer->setBackgroundColor(0.3, 0.3, 0.3, v2);
-    viewer->addText("filtered cloud with decimation, spatial & termporal", 10, 10, "v2 text", v2);
+    viewer.createViewPort(0.5, 0.0, 1.0, 1.0, v2);
+    viewer.setBackgroundColor(0.3, 0.3, 0.3, v2);
+    viewer.addText("filtered cloud with decimation, spatial & termporal", 10, 10, "v2 text", v2);
     pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> handler2(cloud2, 255, 255, 255);
-    viewer->addPointCloud<pcl::PointXYZ>(cloud2, handler2, "sample cloud2", v2);
+    viewer.addPointCloud<pcl::PointXYZ>(cloud2, handler2, "sample cloud2", v2);
 
-    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 3, "sample cloud1");
-    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 3, "sample cloud2");
+    viewer.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 3, "sample cloud1");
+    viewer.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 3, "sample cloud2");
 //    viewer->addCoordinateSystem(1.0);
 
-    while (!viewer->wasStopped()) {
-        viewer->spinOnce(100);
+    while (!viewer.wasStopped()) {
+        viewer.spinOnce(100);
         std::this_thread::sleep_for(100ms);
     }
 

--- a/src/view/Visualizer.cpp
+++ b/src/view/Visualizer.cpp
@@ -74,7 +74,7 @@ void visual::Visualizer::simpleVisColor(std::vector<pcl::PointCloud<pcl::PointXY
 
 void visual::Visualizer::ptVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud, pcl::PointXYZ pt) {
     pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("3D Viewer"));
-    pcl::PointCloud<pcl::PointXYZ>::Ptr point(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> point(new pcl::PointCloud<pcl::PointXYZ>);
     point->push_back(pt);
 
     viewer->setBackgroundColor(0, 0, 0);

--- a/src/view/Visualizer.cpp
+++ b/src/view/Visualizer.cpp
@@ -74,7 +74,7 @@ void visual::Visualizer::simpleVisColor(std::vector<pcl::PointCloud<pcl::PointXY
 
 void visual::Visualizer::ptVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud, pcl::PointXYZ pt) {
     pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("3D Viewer"));
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> point(new pcl::PointCloud<pcl::PointXYZ>);
+    auto point = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     point->push_back(pt);
 
     viewer->setBackgroundColor(0, 0, 0);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories(
         ${gmock_SOURCE_DIR}/include ${gmock_SOURCE_DIR}
 )
 file(GLOB TEST_SRC_FILES
-        ${swag_scanner_SOURCE_DIR}}/test/*.cpp
+        ${swag_scanner_SOURCE_DIR}/test/*.cpp
         ${swag_scanner_SOURCE_DIR}/test/calibrationTests/*.cpp
         ${swag_scanner_SOURCE_DIR}/test/equationsTests/*.cpp
         ${swag_scanner_SOURCE_DIR}/test/fileTests/*.cpp

--- a/test/calibrationTests/CalibrationTests.cpp
+++ b/test/calibrationTests/CalibrationTests.cpp
@@ -75,9 +75,9 @@ TEST_F(CalibrationPhysicalFixture, TestBuildbMatrix) {
 TEST_F(CalibrationPhysicalFixture, VisualizePlaneCalibration) {
 
     std::string folder_path = "/Users/seanngpack/Programming Stuff/Projects/scanner_files/18";
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudOut(new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr transformed(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOut(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transformed(new pcl::PointCloud<pcl::PointXYZ>);
     pcl::io::loadPCDFile<pcl::PointXYZ>(folder_path + "/filtered/" + "1.pcd", *cloudIn);
     pcl::io::loadPCDFile<pcl::PointXYZ>(folder_path + "/filtered/" + "4.pcd", *cloudOut);
 //    std::vector<float> coefs = mod->get_plane_coefs(cloudIn);

--- a/test/calibrationTests/CalibrationTests.cpp
+++ b/test/calibrationTests/CalibrationTests.cpp
@@ -1,12 +1,13 @@
 #include <gtest/gtest.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-#include "../../src/model/processing/Model.h"
-#include "../../src/view/Visualizer.h"
-#include "../../src/model/processing/Segmentation.h"
-#include "../../src/utils/Algorithms.h"
-#include "../../src/model/calibration/Calibration.h"
-#include "../../src/model/equations/Point.h"
+#include <memory>
+#include "Model.h"
+#include "Visualizer.h"
+#include "Segmentation.h"
+#include "Algorithms.h"
+#include "Calibration.h"
+#include "Point.h"
 
 
 class CalibrationPhysicalFixture : public ::testing::Test {
@@ -75,9 +76,9 @@ TEST_F(CalibrationPhysicalFixture, TestBuildbMatrix) {
 TEST_F(CalibrationPhysicalFixture, VisualizePlaneCalibration) {
 
     std::string folder_path = "/Users/seanngpack/Programming Stuff/Projects/scanner_files/18";
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOut(new pcl::PointCloud<pcl::PointXYZ>);
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transformed(new pcl::PointCloud<pcl::PointXYZ>);
+    auto cloudIn = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto cloudOut = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto transformed = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     pcl::io::loadPCDFile<pcl::PointXYZ>(folder_path + "/filtered/" + "1.pcd", *cloudIn);
     pcl::io::loadPCDFile<pcl::PointXYZ>(folder_path + "/filtered/" + "4.pcd", *cloudOut);
 //    std::vector<float> coefs = mod->get_plane_coefs(cloudIn);

--- a/test/fileTests/ScanFileHandlerPhysicalTests.cpp
+++ b/test/fileTests/ScanFileHandlerPhysicalTests.cpp
@@ -28,14 +28,14 @@
 //    */
 //    void set_up_test_files() {
 //        if (boost::filesystem::is_empty(folder_path)) {
-//            pcl::PointCloud<pcl::PointXYZ>::Ptr cloud = set_up_point_cloud();
+//            std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud = set_up_point_cloud();
 //            pcl::io::savePCDFileASCII(folder_path + "/" + "test_cloud.pcd", *cloud);
 //        }
 //    }
 //
-//    static pcl::PointCloud<pcl::PointXYZ>::Ptr set_up_point_cloud() {
+//    static std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> set_up_point_cloud() {
 //        // set up point cloud
-//        pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+//        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud(new pcl::PointCloud<pcl::PointXYZ>);
 //        cloud->height = 10;
 //        cloud->width = 10;
 //        cloud->is_dense = true;
@@ -53,7 +53,7 @@
 //
 //TEST_F(ScanFileHandlerPhysicalFixture, TestLoadCloud) {
 //    // make an empty cloud to cloud the file into.
-//    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+//    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud(new pcl::PointCloud<pcl::PointXYZ>);
 //    // load the file
 //    pcl::io::loadPCDFile<pcl::PointXYZ>(folder_path + "/" + "test_cloud.pcd", *cloud);
 //    ASSERT_EQ(cloud->height, 10);
@@ -66,8 +66,8 @@
 // */
 //TEST_F(ScanFileHandlerPhysicalFixture, TestLoadClouds) {
 //    // make an empty cloud to cloud the file into.
-//    std::vector<pcl::PointCloud<pcl::PointXYZ>::Ptr,
-//            Eigen::aligned_allocator<pcl::PointCloud<pcl::PointXYZ>::Ptr> > data;
+//    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>,
+//            Eigen::aligned_allocator<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> > data;
 //    handler->load_clouds(data, CloudType::Type::RAW);
 //    ASSERT_EQ(data.size(), 4);
 //

--- a/test/processingTests/DepthTests.cpp
+++ b/test/processingTests/DepthTests.cpp
@@ -49,7 +49,7 @@ protected:
 TEST_F(DepthFixture, TestCreatePC) {
     const uint16_t *swag = frame.data();
     std::vector<uint16_t> depth_frame(swag, swag + sizeof swag / sizeof swag[0]);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud = depth::create_point_cloud(depth_frame, *intrinsics_no_distoration);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud = depth::create_point_cloud(depth_frame, *intrinsics_no_distoration);
 
     ASSERT_EQ(cloud->width, 640);
     ASSERT_EQ(cloud->height, 480);

--- a/test/processingTests/ModelPhysicalTests.cpp
+++ b/test/processingTests/ModelPhysicalTests.cpp
@@ -30,14 +30,14 @@ protected:
 
 //TEST_F(ModelPhysicalFixture, TestICP) {
 //    GTEST_SKIP();
-//    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
-//    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudOut(new pcl::PointCloud<pcl::PointXYZ>);
-//    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudInFiltered(new pcl::PointCloud<pcl::PointXYZ>);
-//    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudOutFiltered(new pcl::PointCloud<pcl::PointXYZ>);
-//    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudInSegmented(new pcl::PointCloud<pcl::PointXYZ>);
-//    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudOutSegmented(new pcl::PointCloud<pcl::PointXYZ>);
-//    pcl::PointCloud<pcl::PointXYZ>::Ptr finalCloud(new pcl::PointCloud<pcl::PointXYZ>);
-//    pcl::PointCloud<pcl::PointXYZ>::Ptr transformedCloud(new pcl::PointCloud<pcl::PointXYZ>);
+//    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
+//    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOut(new pcl::PointCloud<pcl::PointXYZ>);
+//    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudInFiltered(new pcl::PointCloud<pcl::PointXYZ>);
+//    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOutFiltered(new pcl::PointCloud<pcl::PointXYZ>);
+//    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudInSegmented(new pcl::PointCloud<pcl::PointXYZ>);
+//    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOutSegmented(new pcl::PointCloud<pcl::PointXYZ>);
+//    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> finalCloud(new pcl::PointCloud<pcl::PointXYZ>);
+//    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transformedCloud(new pcl::PointCloud<pcl::PointXYZ>);
 //    pcl::io::loadPCDFile<pcl::PointXYZ>(test_folder_path + "/raw/" + "1.pcd", *cloudIn);
 //    pcl::io::loadPCDFile<pcl::PointXYZ>(test_folder_path + "/raw/" + "2.pcd", *cloudOut);
 //    std::cout << cloudIn->isOrganized() << std::endl;

--- a/test/processingTests/ModelTests.cpp
+++ b/test/processingTests/ModelTests.cpp
@@ -24,7 +24,7 @@ protected:
         }
 
         // set up point cloud
-        cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+        auto cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
         cloud->height = 10;
         cloud->width = 10;
         cloud->is_dense = true;
@@ -38,6 +38,14 @@ protected:
         cloud_ptr = cloud;
     }
 
+    float distortion[5] = {.139, .124, .0043, .00067, -.034};
+    camera::intrinsics *intrinsics_distortion = new camera::intrinsics(10, 10,
+                                                                       475.07, 475.07,
+                                                                       309.931, 245.011,
+                                                                       RS2_DISTORTION_INVERSE_BROWN_CONRADY,
+                                                                       distortion,
+                                                                       0.0001);
+
     virtual void TearDown() {
         delete mod;
     }
@@ -48,13 +56,7 @@ protected:
  * Test creating a point cloud.
  */
 TEST_F(ModelFixture, TestCreatePointCloud) {
-    float distortion[5] = {.139, .124, .0043, .00067, -.034};
-    camera::intrinsics *intrinsics_distortion = new camera::intrinsics(10, 10,
-                                                                       475.07, 475.07,
-                                                                       309.931, 245.011,
-                                                                       RS2_DISTORTION_INVERSE_BROWN_CONRADY,
-                                                                       distortion,
-                                                                       0.0001);
+
 
     std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> test = mod->create_point_cloud(depth_frame, *intrinsics_distortion);
     EXPECT_EQ(test->width, 10);
@@ -65,7 +67,7 @@ TEST_F(ModelFixture, TestCreatePointCloud) {
  * Test creating the normals cloud.
  */
 TEST_F(ModelFixture, TestEstimateNormals) {
-    auto test = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto test = mod->create_point_cloud(depth_frame, *intrinsics_distortion);
     mod->estimate_normal_cloud(test);
 
     ASSERT_EQ(test->width, 10);

--- a/test/processingTests/ModelTests.cpp
+++ b/test/processingTests/ModelTests.cpp
@@ -9,7 +9,7 @@ class ModelFixture : public ::testing::Test {
 
 protected:
     std::vector<uint16_t> depth_frame;
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_ptr;
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud_ptr;
     model::Model *mod;
 
 
@@ -23,7 +23,7 @@ protected:
         }
 
         // set up point cloud
-        pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud(new pcl::PointCloud<pcl::PointXYZ>);
         cloud->height = 10;
         cloud->width = 10;
         cloud->is_dense = true;
@@ -55,7 +55,7 @@ TEST_F(ModelFixture, TestCreatePointCloud) {
                                                                        distortion,
                                                                        0.0001);
 
-    pcl::PointCloud<pcl::PointXYZ>::Ptr test = mod->create_point_cloud(depth_frame, *intrinsics_distortion);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> test = mod->create_point_cloud(depth_frame, *intrinsics_distortion);
     EXPECT_EQ(test->width, 10);
     EXPECT_EQ(test->height, 10);
 }
@@ -64,7 +64,7 @@ TEST_F(ModelFixture, TestCreatePointCloud) {
  * Test creating the normals cloud.
  */
 TEST_F(ModelFixture, TestEstimateNormals) {
-    pcl::PointCloud<pcl::PointXYZ>::Ptr test(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> test(new pcl::PointCloud<pcl::PointXYZ>);
     mod->estimate_normal_cloud(test);
 
     ASSERT_EQ(test->width, 10);

--- a/test/processingTests/ModelTests.cpp
+++ b/test/processingTests/ModelTests.cpp
@@ -3,6 +3,7 @@
 #include <pcl/point_types.h>
 #include "Model.h"
 #include "CameraTypes.h"
+#include <memory>
 
 
 class ModelFixture : public ::testing::Test {
@@ -64,7 +65,7 @@ TEST_F(ModelFixture, TestCreatePointCloud) {
  * Test creating the normals cloud.
  */
 TEST_F(ModelFixture, TestEstimateNormals) {
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> test(new pcl::PointCloud<pcl::PointXYZ>);
+    auto test = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     mod->estimate_normal_cloud(test);
 
     ASSERT_EQ(test->width, 10);

--- a/test/processingTests/ModelTests.cpp
+++ b/test/processingTests/ModelTests.cpp
@@ -23,7 +23,7 @@ protected:
         }
 
         // set up point cloud
-        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud(new pcl::PointCloud<pcl::PointXYZ>);
+        cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
         cloud->height = 10;
         cloud->width = 10;
         cloud->is_dense = true;

--- a/test/processingTests/SegmentationPhysicalTets.cpp
+++ b/test/processingTests/SegmentationPhysicalTets.cpp
@@ -47,7 +47,7 @@ TEST(SegmentationPhysicalTests, ViewAxis) {
     GTEST_SKIP();
     using namespace std::chrono_literals;
     std::string folder_path = "/Users/seanngpack/Library/Application Support/SwagScanner/calibration";
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
+    auto cloudIn = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     pcl::io::loadPCDFile<pcl::PointXYZ>(folder_path + "/processed_1/15.pcd", *cloudIn);
 
     pcl::PointXYZ p1;

--- a/test/processingTests/SegmentationPhysicalTets.cpp
+++ b/test/processingTests/SegmentationPhysicalTets.cpp
@@ -13,10 +13,10 @@
 TEST(SegmentationPhysicalTests, TestRemovePlane) {
     GTEST_SKIP();
     std::string test_folder_path = "/Users/seanngpack/Programming Stuff/Projects/scanner_files/testing/FileHandlerPhysicalTests";
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOut(new pcl::PointCloud<pcl::PointXYZ>);
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudInSegmented(new pcl::PointCloud<pcl::PointXYZ>);
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOutSegmented(new pcl::PointCloud<pcl::PointXYZ>);
+    auto cloudIn = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto cloudOut = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto cloudInSegmented = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto cloudOutSegmented = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
 
     pcl::io::loadPCDFile<pcl::PointXYZ>(test_folder_path + "/raw/" + "1.pcd", *cloudIn);
     pcl::io::loadPCDFile<pcl::PointXYZ>(test_folder_path + "/raw/" + "2.pcd", *cloudOut);
@@ -33,9 +33,9 @@ TEST(SegmentationPhysicalTests, TestRemovePlane) {
 
 TEST(SegmentationPhysicalTests, TestGetPlanes) {
     std::string folder_path = "/Users/seanngpack/Library/Application Support/SwagScanner/calibration/fish_cup";
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::io::loadPCDFile<pcl::PointXYZ>(folder_path + "/10.pcd", *cloudIn);
-    segmentation::get_calibration_planes_coefs(cloudIn);
+    auto cloud_in = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    pcl::io::loadPCDFile<pcl::PointXYZ>(folder_path + "/10.pcd", *cloud_in);
+    segmentation::get_calibration_planes_coefs(cloud_in);
 
 //    visual::Visualizer *viewer;
 //    viewer->simpleVis(cloudIn);
@@ -60,7 +60,6 @@ TEST(SegmentationPhysicalTests, ViewAxis) {
     p2.x = -0.2867;
     p2.y = -14.6891;
     p2.z = -8.0644;
-
 
 
     pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("3D Viewer"));

--- a/test/processingTests/SegmentationPhysicalTets.cpp
+++ b/test/processingTests/SegmentationPhysicalTets.cpp
@@ -62,15 +62,15 @@ TEST(SegmentationPhysicalTests, ViewAxis) {
     p2.z = -8.0644;
 
 
-    pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("3D Viewer"));
-    viewer->setBackgroundColor(0, 0, 0);
-    viewer->addPointCloud<pcl::PointXYZ>(cloudIn, "sample cloud");
-    viewer->addLine(p1, p2, std::string("line"), 0);
-    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 1, "sample cloud");
-    viewer->addCoordinateSystem(1.0);
-    viewer->initCameraParameters();
-    while (!viewer->wasStopped()) {
-        viewer->spinOnce(100);
+    pcl::visualization::PCLVisualizer viewer("3D Viewer");
+    viewer.setBackgroundColor(0, 0, 0);
+    viewer.addPointCloud<pcl::PointXYZ>(cloudIn, "sample cloud");
+    viewer.addLine(p1, p2, std::string("line"), 0);
+    viewer.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 1, "sample cloud");
+    viewer.addCoordinateSystem(1.0);
+    viewer.initCameraParameters();
+    while (!viewer.wasStopped()) {
+        viewer.spinOnce(100);
         std::this_thread::sleep_for(100ms);
     }
 }

--- a/test/processingTests/SegmentationPhysicalTets.cpp
+++ b/test/processingTests/SegmentationPhysicalTets.cpp
@@ -13,10 +13,10 @@
 TEST(SegmentationPhysicalTests, TestRemovePlane) {
     GTEST_SKIP();
     std::string test_folder_path = "/Users/seanngpack/Programming Stuff/Projects/scanner_files/testing/FileHandlerPhysicalTests";
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudOut(new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudInSegmented(new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudOutSegmented(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOut(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudInSegmented(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOutSegmented(new pcl::PointCloud<pcl::PointXYZ>);
 
     pcl::io::loadPCDFile<pcl::PointXYZ>(test_folder_path + "/raw/" + "1.pcd", *cloudIn);
     pcl::io::loadPCDFile<pcl::PointXYZ>(test_folder_path + "/raw/" + "2.pcd", *cloudOut);
@@ -33,7 +33,7 @@ TEST(SegmentationPhysicalTests, TestRemovePlane) {
 
 TEST(SegmentationPhysicalTests, TestGetPlanes) {
     std::string folder_path = "/Users/seanngpack/Library/Application Support/SwagScanner/calibration/fish_cup";
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
     pcl::io::loadPCDFile<pcl::PointXYZ>(folder_path + "/10.pcd", *cloudIn);
     segmentation::get_calibration_planes_coefs(cloudIn);
 
@@ -47,7 +47,7 @@ TEST(SegmentationPhysicalTests, ViewAxis) {
     GTEST_SKIP();
     using namespace std::chrono_literals;
     std::string folder_path = "/Users/seanngpack/Library/Application Support/SwagScanner/calibration";
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
     pcl::io::loadPCDFile<pcl::PointXYZ>(folder_path + "/processed_1/15.pcd", *cloudIn);
 
     pcl::PointXYZ p1;

--- a/test/typesTests/CloudTypeTests.cpp
+++ b/test/typesTests/CloudTypeTests.cpp
@@ -13,7 +13,8 @@ TEST(CloudTypeTests, TestEnumForLoop) {
 
     ASSERT_EQ(v[0], "raw");
     ASSERT_EQ(v[1], "filtered");
-    ASSERT_EQ(v[2], "segmented");
+    ASSERT_EQ(v[2], "processed");
     ASSERT_EQ(v[3], "normal");
+    ASSERT_EQ(v[4], "calibration");
 
 }

--- a/test/utilsTests/AlgosTests.cpp
+++ b/test/utilsTests/AlgosTests.cpp
@@ -118,7 +118,7 @@ TEST_F(AlgosFixture, TestTransformCoordinate) {
     Eigen::Transform<float, 3, Eigen::Affine> combined =
             rot * translation;
     std::cout << combined.matrix() << std::endl;
-    pcl::transformPointCloud(*cloudIn, *result, combined.matrix());
+    pcl::transformPointCloud(*cloud_in, *result, combined.matrix());
 
     model::Model model;
     result_cropped = model.crop_cloud(result, -.089, .089,
@@ -126,7 +126,7 @@ TEST_F(AlgosFixture, TestTransformCoordinate) {
                                       -.03, .05);
 
     visual::Visualizer visualizer;
-    std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr> clouds{cloudIn, result};
+    std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr> clouds{cloud_in, result};
 //    std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr> clouds{result, result_cropped};
     visualizer.simpleVisColor(clouds);
 //    visualizer.ptVis(cloudIn, pt);

--- a/test/utilsTests/AlgosTests.cpp
+++ b/test/utilsTests/AlgosTests.cpp
@@ -87,9 +87,9 @@ TEST_F(AlgosFixture, TestDeprojectDistortion) {
 TEST_F(AlgosFixture, TestTransformCoordinate) {
 
     std::string folder_path = "/Users/seanngpack/Library/Application Support/SwagScanner/calibration/test5/12.pcd";
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr result(new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr result_cropped(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> result(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> result_cropped(new pcl::PointCloud<pcl::PointXYZ>);
     pcl::PointXYZ pt(-0.006283042311759926,
                      0.014217784268003741,
                      0.4304016110847342);

--- a/test/utilsTests/AlgosTests.cpp
+++ b/test/utilsTests/AlgosTests.cpp
@@ -87,14 +87,14 @@ TEST_F(AlgosFixture, TestDeprojectDistortion) {
 TEST_F(AlgosFixture, TestTransformCoordinate) {
 
     std::string folder_path = "/Users/seanngpack/Library/Application Support/SwagScanner/calibration/test5/12.pcd";
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn(new pcl::PointCloud<pcl::PointXYZ>);
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> result(new pcl::PointCloud<pcl::PointXYZ>);
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> result_cropped(new pcl::PointCloud<pcl::PointXYZ>);
+    auto cloud_in = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto result = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    auto result_cropped = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     pcl::PointXYZ pt(-0.006283042311759926,
                      0.014217784268003741,
                      0.4304016110847342);
 
-    pcl::io::loadPCDFile<pcl::PointXYZ>(folder_path, *cloudIn);
+    pcl::io::loadPCDFile<pcl::PointXYZ>(folder_path, *cloud_in);
 
     //point -> origin so I flipped the signs
     // NOTE I FLIPPED THE SIGNS OF ORIGINAL


### PR DESCRIPTION
- refactored boost smart ptrs to std smart ptrs
- fixed some instances where it is better to use local objects instead of pointers. Can't change all of them because a lot of PCL API requires a smart pointer as argument type. Refactor more in a different branch.
- fixed unit tests