### PR TITLE
Pointers cleanup

### DIFF
--- a/src/cli/ControllerFactory.cpp
+++ b/src/cli/ControllerFactory.cpp
@@ -17,7 +17,7 @@
 
 namespace po = boost::program_options;
 
-std::unique_ptr<controller::IController> cli::ControllerFactory::create(po::variables_map vm) {
+std::unique_ptr<controller::IController> cli::ControllerFactory::create(const po::variables_map &vm) {
     if (vm.count("scan")) {
         return create_scan_controller(vm);
     } else if (vm.count("calibrate")) {
@@ -36,7 +36,7 @@ std::unique_ptr<controller::IController> cli::ControllerFactory::create(po::vari
 }
 
 std::unique_ptr<controller::IController>
-cli::ControllerFactory::create_scan_controller(boost::program_options::variables_map vm) {
+cli::ControllerFactory::create_scan_controller(const po::variables_map &vm) {
     std::shared_ptr<file::ScanFileHandler> file_handler;
     if (vm.count("name")) {
         const char *c = vm["name"].as<std::string>().c_str();
@@ -61,7 +61,7 @@ cli::ControllerFactory::create_scan_controller(boost::program_options::variables
 }
 
 std::unique_ptr<controller::IController>
-cli::ControllerFactory::create_calibrate_controller(boost::program_options::variables_map vm) {
+cli::ControllerFactory::create_calibrate_controller(const po::variables_map &vm) {
     std::shared_ptr<file::CalibrationFileHandler> file_handler;
     if (vm.count("name")) {
         const char *c = vm["name"].as<std::string>().c_str();
@@ -87,7 +87,7 @@ cli::ControllerFactory::create_calibrate_controller(boost::program_options::vari
 }
 
 std::unique_ptr<controller::IController>
-cli::ControllerFactory::create_processing_controller(boost::program_options::variables_map vm) {
+cli::ControllerFactory::create_processing_controller(const po::variables_map &vm) {
     std::shared_ptr<file::ScanFileHandler> file_handler;
     if (vm.count("name")) {
         const char *c = vm["name"].as<std::string>().c_str();
@@ -101,7 +101,7 @@ cli::ControllerFactory::create_processing_controller(boost::program_options::var
 }
 
 std::unique_ptr<controller::IController>
-cli::ControllerFactory::create_filter_testing_controller(boost::program_options::variables_map vm) {
+cli::ControllerFactory::create_filter_testing_controller(const po::variables_map &vm) {
     std::shared_ptr<camera::SR305> camera = std::make_shared<camera::SR305>();
     if (vm.count("d_mag")) {
         camera->set_decimation_magnitude(vm["d_mag"].as<int>());
@@ -122,7 +122,7 @@ cli::ControllerFactory::create_filter_testing_controller(boost::program_options:
 }
 
 std::unique_ptr<controller::IController>
-cli::ControllerFactory::create_move_controller(boost::program_options::variables_map vm) {
+cli::ControllerFactory::create_move_controller(const po::variables_map &vm) {
     auto arduino = std::make_shared<arduino::Arduino>();
     std::unique_ptr<controller::MoveController> move_controller = std::make_unique<controller::MoveController>(arduino);
     if (vm.count("to")) {
@@ -139,7 +139,7 @@ cli::ControllerFactory::create_move_controller(boost::program_options::variables
 }
 
 std::unique_ptr<controller::IController>
-cli::ControllerFactory::create_home_controller(boost::program_options::variables_map vm) {
+cli::ControllerFactory::create_home_controller(const po::variables_map &vm) {
     return std::make_unique<controller::HomeController>();
 }
 

--- a/src/cli/ControllerFactory.h
+++ b/src/cli/ControllerFactory.h
@@ -13,7 +13,7 @@ namespace cli {
 
         ControllerFactory() = default;
 
-        std::unique_ptr<controller::IController> create(boost::program_options::variables_map vm);
+        std::unique_ptr<controller::IController> create(const boost::program_options::variables_map &vm);
 
 
     private:
@@ -25,7 +25,7 @@ namespace cli {
          * @return
          */
         std::unique_ptr<controller::IController>
-        create_scan_controller(boost::program_options::variables_map vm);
+        create_scan_controller(const boost::program_options::variables_map &vm);
 
         /**
          * Creates a new calibration controller. If -name is not passed then it will
@@ -34,7 +34,7 @@ namespace cli {
          * @return
          */
         std::unique_ptr<controller::IController>
-        create_calibrate_controller(boost::program_options::variables_map vm);
+        create_calibrate_controller(const boost::program_options::variables_map &vm);
 
         /**
          * Create a processing controller. If -name is not passed then it will use the latest scan according
@@ -43,7 +43,7 @@ namespace cli {
          * @return
          */
         std::unique_ptr<controller::IController>
-        create_processing_controller(boost::program_options::variables_map vm);
+        create_processing_controller(const boost::program_options::variables_map &vm);
 
         /**
          * Create a filter testing controller.
@@ -51,7 +51,7 @@ namespace cli {
          * @return
          */
         std::unique_ptr<controller::IController>
-        create_filter_testing_controller(boost::program_options::variables_map vm);
+        create_filter_testing_controller(const boost::program_options::variables_map &vm);
 
         /**
          * Create a move controller.
@@ -59,7 +59,7 @@ namespace cli {
          * @return
          */
         std::unique_ptr<controller::IController>
-        create_move_controller(boost::program_options::variables_map vm);
+        create_move_controller(const boost::program_options::variables_map &vm);
 
         /**
          * Create a home controller to set home position.
@@ -67,7 +67,7 @@ namespace cli {
          * @return
          */
         std::unique_ptr<controller::IController>
-        create_home_controller(boost::program_options::variables_map vm);
+        create_home_controller(const boost::program_options::variables_map &vm);
     };
 }
 

--- a/src/controller/CalibrationController.cpp
+++ b/src/controller/CalibrationController.cpp
@@ -24,8 +24,8 @@ controller::CalibrationController::CalibrationController(std::shared_ptr<camera:
 
 void controller::CalibrationController::run() {
     scan();
-    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector;
-    file_handler->load_clouds(cloud_vector, CloudType::Type::CALIBRATION);
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector = file_handler->load_clouds(
+            CloudType::Type::CALIBRATION);
     equations::Normal axis_dir = model->calculate_axis_dir(ground_planes);
     equations::Point center = model->calculate_center_pt(axis_dir, upright_planes);
     file_handler->update_calibration_json(axis_dir, center);

--- a/src/controller/ProcessingController.cpp
+++ b/src/controller/ProcessingController.cpp
@@ -18,7 +18,7 @@ void controller::ProcessingController::run() {
     rotate_all_clouds(CloudType::Type::FILTERED);
 }
 
-void controller::ProcessingController::crop_clouds(CloudType::Type cloud_type) {
+void controller::ProcessingController::crop_clouds(const CloudType::Type &cloud_type) {
     using namespace constants;
 
     std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector = file_handler->load_clouds(cloud_type);
@@ -33,7 +33,7 @@ void controller::ProcessingController::crop_clouds(CloudType::Type cloud_type) {
     }
 }
 
-void controller::ProcessingController::remove_planes(CloudType::Type cloud_type) {
+void controller::ProcessingController::remove_planes(const CloudType::Type &cloud_type) {
     std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector = file_handler->load_clouds(cloud_type);
     for (int i = 0; i < cloud_vector.size(); i++) {
         std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
@@ -44,7 +44,7 @@ void controller::ProcessingController::remove_planes(CloudType::Type cloud_type)
 }
 
 
-void controller::ProcessingController::register_all_clouds(CloudType::Type cloud_type) {
+void controller::ProcessingController::register_all_clouds(const CloudType::Type &cloud_type) {
     std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector = file_handler->load_clouds(cloud_type);
     Eigen::Matrix4f global_transform = Eigen::Matrix4f::Identity();
     auto source = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
@@ -72,7 +72,7 @@ void controller::ProcessingController::register_all_clouds(CloudType::Type cloud
     visualize_cloud(global_cloud);
 }
 
-void controller::ProcessingController::rotate_all_clouds(CloudType::Type cloud_type) {
+void controller::ProcessingController::rotate_all_clouds(const CloudType::Type &cloud_type) {
     std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector = file_handler->load_clouds(cloud_type);
     json info_json = file_handler->get_info_json();
     json calibration_json = file_handler->get_calibration_json();
@@ -92,6 +92,6 @@ void controller::ProcessingController::rotate_all_clouds(CloudType::Type cloud_t
     viewer->simpleVis(global_cloud);
 }
 
-void controller::ProcessingController::visualize_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
+void controller::ProcessingController::visualize_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud) {
     viewer->simpleVis(cloud);
 }

--- a/src/controller/ProcessingController.cpp
+++ b/src/controller/ProcessingController.cpp
@@ -21,8 +21,7 @@ void controller::ProcessingController::run() {
 void controller::ProcessingController::crop_clouds(CloudType::Type cloud_type) {
     using namespace constants;
 
-    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector;
-    file_handler->load_clouds(cloud_vector, cloud_type);
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector = file_handler->load_clouds(cloud_type);
     for (int i = 0; i < cloud_vector.size(); i++) {
         std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
                 cropped_cloud = model->crop_cloud(cloud_vector[i],
@@ -35,8 +34,7 @@ void controller::ProcessingController::crop_clouds(CloudType::Type cloud_type) {
 }
 
 void controller::ProcessingController::remove_planes(CloudType::Type cloud_type) {
-    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector;
-    file_handler->load_clouds(cloud_vector, cloud_type);
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector = file_handler->load_clouds(cloud_type);
     for (int i = 0; i < cloud_vector.size(); i++) {
         std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
                 segmented_cloud = model->remove_plane(cloud_vector[i]);
@@ -47,8 +45,7 @@ void controller::ProcessingController::remove_planes(CloudType::Type cloud_type)
 
 
 void controller::ProcessingController::register_all_clouds(CloudType::Type cloud_type) {
-    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector;
-    file_handler->load_clouds(cloud_vector, cloud_type);
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector = file_handler->load_clouds(cloud_type);
     Eigen::Matrix4f global_transform = Eigen::Matrix4f::Identity();
     auto source = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     auto target = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
@@ -76,8 +73,7 @@ void controller::ProcessingController::register_all_clouds(CloudType::Type cloud
 }
 
 void controller::ProcessingController::rotate_all_clouds(CloudType::Type cloud_type) {
-    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector;
-    file_handler->load_clouds(cloud_vector, cloud_type);
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector = file_handler->load_clouds(cloud_type);
     json info_json = file_handler->get_info_json();
     json calibration_json = file_handler->get_calibration_json();
 

--- a/src/controller/ProcessingController.h
+++ b/src/controller/ProcessingController.h
@@ -42,7 +42,7 @@ namespace controller {
          * @param cloud_type which cloud types do you want to crop.
          * @param leaf size.
          */
-        void crop_clouds(CloudType::Type cloud_type);
+        void crop_clouds(const CloudType::Type &cloud_type);
 
         /**
          * Segment and save the clouds in the given folder path to the /segmented folder.
@@ -51,23 +51,23 @@ namespace controller {
          * /filtered folder.
          *
          */
-        void remove_planes(CloudType::Type cloud_type);
+        void remove_planes(const CloudType::Type &cloud_type);
 
         /**
          * Register all point clouds in given folder location.
          * @param folder_path the path to the scan folder.
          * @param cloud_type the type of the cloud, tells which folder to look into for clouds.
          */
-        void register_all_clouds(CloudType::Type cloud_type);
+        void register_all_clouds(const CloudType::Type &cloud_type);
 
         /**
          * Use rotation axis to align all clouds to initial.
          * @param cloud_type type determines which folder you want to select clouds from.
          */
-        void rotate_all_clouds(CloudType::Type cloud_type);
+        void rotate_all_clouds(const CloudType::Type &cloud_type);
 
 
-        void visualize_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud);
+        void visualize_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud);
 
     private:
         std::shared_ptr<model::Model> model;

--- a/src/file/CalibrationFileHandler.cpp
+++ b/src/file/CalibrationFileHandler.cpp
@@ -40,13 +40,14 @@ void file::CalibrationFileHandler::save_cloud(const std::shared_ptr<pcl::PointCl
     pcl::io::savePCDFileASCII(out_path.string(), *cloud);
 }
 
-void file::CalibrationFileHandler::load_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
-                                              const std::string &cloud_name,
-                                              const CloudType::Type &cloud_type) {
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> file::CalibrationFileHandler::load_cloud(const std::string &cloud_name,
+                                                                                         const CloudType::Type &cloud_type) {
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud;
     path open_path = scan_folder_path / cloud_name;
     if (pcl::io::loadPCDFile<pcl::PointXYZ>(open_path.string(), *cloud) == -1) {
         PCL_ERROR ("Couldn't read file \n");
     }
+    return cloud;
 }
 
 std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> file::CalibrationFileHandler::load_clouds(

--- a/src/file/CalibrationFileHandler.cpp
+++ b/src/file/CalibrationFileHandler.cpp
@@ -31,27 +31,27 @@ file::CalibrationFileHandler::CalibrationFileHandler(const char *scan_name) {
     }
 }
 
-void file::CalibrationFileHandler::save_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+void file::CalibrationFileHandler::save_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                                               const std::string &cloud_name,
-                                              CloudType::Type cloud_type) {
+                                              const CloudType::Type &cloud_type) {
     std::cout << "saving file to ";
     path out_path = scan_folder_path / cloud_name;
     std::cout << out_path << std::endl;
     pcl::io::savePCDFileASCII(out_path.string(), *cloud);
 }
 
-void file::CalibrationFileHandler::load_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+void file::CalibrationFileHandler::load_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                                               const std::string &cloud_name,
-                                              CloudType::Type cloud_type) {
+                                              const CloudType::Type &cloud_type) {
     path open_path = scan_folder_path / cloud_name;
     if (pcl::io::loadPCDFile<pcl::PointXYZ>(open_path.string(), *cloud) == -1) {
         PCL_ERROR ("Couldn't read file \n");
     }
 }
 
-void file::CalibrationFileHandler::load_clouds(
-        std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &cloud_vector,
-        CloudType::Type cloud_type) {
+std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> file::CalibrationFileHandler::load_clouds(
+        const CloudType::Type &cloud_type) {
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector;
     std::vector<path> cloud_paths;
     path load_path = scan_folder_path;
 
@@ -76,6 +76,7 @@ void file::CalibrationFileHandler::load_clouds(
         cloud_vector.push_back(cloud);
     }
     std::cout << "finished loading clouds" << std::endl;
+    return cloud_vector;
 }
 
 std::string file::CalibrationFileHandler::get_scan_name() {
@@ -86,7 +87,7 @@ void file::CalibrationFileHandler::set_scan_name(const std::string &scan_name) {
     this->scan_name = scan_name;
 }
 
-void file::CalibrationFileHandler::update_calibration_json(equations::Normal dir, equations::Point pt) {
+void file::CalibrationFileHandler::update_calibration_json(const equations::Normal &dir, const equations::Point &pt) {
     json calibration_json = get_calibration_json();
     calibration_json["axis direction"] = {dir.A, dir.B, dir.C};
     calibration_json["origin point"] = {pt.x, pt.y, pt.z};

--- a/src/file/CalibrationFileHandler.h
+++ b/src/file/CalibrationFileHandler.h
@@ -4,8 +4,9 @@
 #include "IFileHandler.h"
 #include <nlohmann/json.hpp>
 
-namespace equations{
+namespace equations {
     class Normal;
+
     class Point;
 }
 
@@ -33,17 +34,16 @@ namespace file {
          */
         CalibrationFileHandler(const char *scan_name);
 
-        void save_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+        void save_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                         const std::string &cloud_name,
-                        CloudType::Type cloud_type) override;
+                        const CloudType::Type &cloud_type) override;
 
-        void load_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+        void load_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                         const std::string &cloud_name,
-                        CloudType::Type cloud_type) override;
+                        const CloudType::Type &cloud_type) override;
 
-        void load_clouds(
-                std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &cloud_vector,
-                CloudType::Type cloud_type) override;
+        std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> load_clouds(
+                const CloudType::Type &cloud_type) override;
 
         std::string get_scan_name() override;
 
@@ -55,7 +55,7 @@ namespace file {
          * @param dir axis direction.
          * @param pt center point.
          */
-        void update_calibration_json(equations::Normal dir, equations::Point pt);
+        void update_calibration_json(const equations::Normal &dir, const equations::Point &pt);
 
     private:
 

--- a/src/file/CalibrationFileHandler.h
+++ b/src/file/CalibrationFileHandler.h
@@ -38,9 +38,8 @@ namespace file {
                         const std::string &cloud_name,
                         const CloudType::Type &cloud_type) override;
 
-        void load_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
-                        const std::string &cloud_name,
-                        const CloudType::Type &cloud_type) override;
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> load_cloud(const std::string &cloud_name,
+                                                                   const CloudType::Type &cloud_type) override;
 
         std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> load_clouds(
                 const CloudType::Type &cloud_type) override;

--- a/src/file/IFileHandler.cpp
+++ b/src/file/IFileHandler.cpp
@@ -25,7 +25,7 @@ json file::IFileHandler::load_settings_json() {
     return settings_json;
 }
 
-void file::IFileHandler::write_settings_json(json j) {
+void file::IFileHandler::write_settings_json(const json &j) {
     std::string settings_path = swag_scanner_path.string() + "/settings/settings.json";
     std::ofstream updated_file(settings_path);
     updated_file << std::setw(4) << j << std::endl; // write to file
@@ -52,7 +52,7 @@ path file::IFileHandler::find_latest_calibration() {
     return p;
 }
 
-bool file::IFileHandler::path_sort(boost::filesystem::path &path1, boost::filesystem::path &path2) {
+bool file::IFileHandler::path_sort(const boost::filesystem::path &path1, const boost::filesystem::path &path2) {
     std::string string1 = path1.string();
     std::string string2 = path2.string();
 
@@ -81,7 +81,7 @@ bool file::IFileHandler::path_sort(boost::filesystem::path &path1, boost::filesy
     return (std::stoi(result1) < std::stoi(result2));
 }
 
-path file::IFileHandler::find_next_scan_folder_numeric(CloudType::Type const &type) {
+path file::IFileHandler::find_next_scan_folder_numeric(const CloudType::Type &type) {
     boost::filesystem::path folder = swag_scanner_path / "/scans";
     if (type == CloudType::Type::CALIBRATION) {
         folder = swag_scanner_path / "calibration";

--- a/src/file/IFileHandler.h
+++ b/src/file/IFileHandler.h
@@ -47,15 +47,15 @@ namespace file {
 
         /*
          * Load a pointcloud from the scan folder given the name and type.
-         * @param cloud the cloud you want to load the cloud into
+         *
          * @param cloud_name name of the cloud.
          * @param cloud_type type of the cloud.
+         * @return cloud.
          *
-         * Example: load_cloud(cloud, "testScan", "12.pcd", CloudType::RAW)
+         * Example: load_cloud("12", CloudType::RAW)
          */
-        virtual void load_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
-                                const std::string &cloud_name,
-                                const CloudType::Type &cloud_type) = 0;
+        virtual std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> load_cloud(const std::string &cloud_name,
+                                                                   const CloudType::Type &cloud_type) = 0;
 
 
         /**
@@ -69,7 +69,8 @@ namespace file {
          * @return vector of loaded cloud pointers.
          *
          */
-        virtual std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> load_clouds(const CloudType::Type &cloud_type) = 0;
+        virtual std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>>
+        load_clouds(const CloudType::Type &cloud_type) = 0;
 
         virtual std::string get_scan_name() = 0;
 

--- a/src/file/IFileHandler.h
+++ b/src/file/IFileHandler.h
@@ -26,7 +26,7 @@ namespace file {
          * Static method write to settings.json.
          * @param j json file that follows format of settings.json
          */
-        static void write_settings_json(nlohmann::json j);
+        static void write_settings_json(const nlohmann::json &j);
 
         /**
          * Go to the SwagScanner/calibration directory and find the latest calibration by date.
@@ -41,9 +41,9 @@ namespace file {
          * @param cloud the cloud you want to save.
          * @para cloud_type enum for the type of cloud you are saving. Affects the subfolder path.
          */
-        virtual void save_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+        virtual void save_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                                 const std::string &cloud_name,
-                                CloudType::Type cloud_type) = 0;
+                                const CloudType::Type &cloud_type) = 0;
 
         /*
          * Load a pointcloud from the scan folder given the name and type.
@@ -53,9 +53,9 @@ namespace file {
          *
          * Example: load_cloud(cloud, "testScan", "12.pcd", CloudType::RAW)
          */
-        virtual void load_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+        virtual void load_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                                 const std::string &cloud_name,
-                                CloudType::Type cloud_type) = 0;
+                                const CloudType::Type &cloud_type) = 0;
 
 
         /**
@@ -64,13 +64,12 @@ namespace file {
          *
          * @Edge case when passed CALIBRATION as the type, it will search through the
          * /calibration folder in the root directory and load the latest calibration.
-         * @param cloud_vector the vector you want to load the clouds into.
+         *
          * @param cloud_type determines which folder to search for.
+         * @return vector of loaded cloud pointers.
          *
          */
-        virtual void load_clouds(std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &cloud_vector,
-                                 CloudType::Type cloud_type) = 0;
-
+        virtual std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> load_clouds(const CloudType::Type &cloud_type) = 0;
 
         virtual std::string get_scan_name() = 0;
 
@@ -91,7 +90,7 @@ namespace file {
          * @param path2 second path.
          * @return true if the first file is smaller than the second, false otherwise.
          */
-        static bool path_sort(boost::filesystem::path &path1, boost::filesystem::path &path2);
+        static bool path_sort(const boost::filesystem::path &path1, const boost::filesystem::path &path2);
 
         /**
          * Find the next scan folder by sorting the existing scans numerically.
@@ -100,7 +99,7 @@ namespace file {
          *
          */
         virtual boost::filesystem::path
-        find_next_scan_folder_numeric(CloudType::Type const &type);
+        find_next_scan_folder_numeric(const CloudType::Type &type);
 
         boost::filesystem::path find_next_scan_folder_numeric();
     };

--- a/src/file/ScanFileHandler.cpp
+++ b/src/file/ScanFileHandler.cpp
@@ -49,13 +49,14 @@ void file::ScanFileHandler::save_cloud(const std::shared_ptr<pcl::PointCloud<pcl
     pcl::io::savePCDFileASCII(out_path.string(), *cloud);
 }
 
-void file::ScanFileHandler::load_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
-                                       const std::string &cloud_name,
-                                       const CloudType::Type &cloud_type) {
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> file::ScanFileHandler::load_cloud(const std::string &cloud_name,
+                                                                                  const CloudType::Type &cloud_type) {
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud;
     path open_path = scan_folder_path / CloudType::String(cloud_type) / cloud_name;
     if (pcl::io::loadPCDFile<pcl::PointXYZ>(open_path.string(), *cloud) == -1) {
         PCL_ERROR ("Couldn't read file \n");
     }
+    return cloud;
 }
 
 

--- a/src/file/ScanFileHandler.cpp
+++ b/src/file/ScanFileHandler.cpp
@@ -40,18 +40,18 @@ file::ScanFileHandler::ScanFileHandler(const char *scan_name) {
 }
 
 
-void file::ScanFileHandler::save_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+void file::ScanFileHandler::save_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                                        const std::string &cloud_name,
-                                       CloudType::Type cloud_type) {
+                                       const CloudType::Type &cloud_type) {
     std::cout << "saving file to ";
     path out_path = scan_folder_path / CloudType::String(cloud_type) / cloud_name;
     std::cout << out_path << std::endl;
     pcl::io::savePCDFileASCII(out_path.string(), *cloud);
 }
 
-void file::ScanFileHandler::load_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+void file::ScanFileHandler::load_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                                        const std::string &cloud_name,
-                                       CloudType::Type cloud_type) {
+                                       const CloudType::Type &cloud_type) {
     path open_path = scan_folder_path / CloudType::String(cloud_type) / cloud_name;
     if (pcl::io::loadPCDFile<pcl::PointXYZ>(open_path.string(), *cloud) == -1) {
         PCL_ERROR ("Couldn't read file \n");
@@ -59,9 +59,9 @@ void file::ScanFileHandler::load_cloud(std::shared_ptr<pcl::PointCloud<pcl::Poin
 }
 
 
-void file::ScanFileHandler::load_clouds(
-        std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &cloud_vector,
-        CloudType::Type cloud_type) {
+std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> file::ScanFileHandler::load_clouds(
+        const CloudType::Type &cloud_type) {
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> cloud_vector;
     std::vector<path> cloud_paths;
     path load_path = scan_folder_path / CloudType::String(cloud_type);
 
@@ -86,6 +86,7 @@ void file::ScanFileHandler::load_clouds(
         cloud_vector.push_back(cloud);
     }
     std::cout << "finished loading clouds" << std::endl;
+    return cloud_vector;
 }
 
 std::string file::ScanFileHandler::get_scan_name() {
@@ -103,7 +104,9 @@ json file::ScanFileHandler::get_info_json() {
     return info_json;
 }
 
-void file::ScanFileHandler::update_info_json(std::string date, int angle, std::string cal) {
+void file::ScanFileHandler::update_info_json(const std::string &date,
+                                             int angle,
+                                             const std::string &cal) {
     json info_json = get_info_json();
     info_json["date"] = date;
     info_json["angle"] = angle;
@@ -184,7 +187,7 @@ void file::ScanFileHandler::create_sub_folders() {
 }
 
 
-void file::ScanFileHandler::set_settings_latest_scan(path folder_path) {
+void file::ScanFileHandler::set_settings_latest_scan(const path &folder_path) {
     std::ifstream settings(swag_scanner_path.string() + "/settings/settings.json");
     json settings_json;
     settings >> settings_json;

--- a/src/file/ScanFileHandler.h
+++ b/src/file/ScanFileHandler.h
@@ -44,9 +44,8 @@ namespace file {
                         const std::string &cloud_name,
                         const CloudType::Type &cloud_type) override;
 
-        void load_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
-                        const std::string &cloud_name,
-                        const CloudType::Type &cloud_type) override;
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> load_cloud(const std::string &cloud_name,
+                                                                   const CloudType::Type &cloud_type) override;
 
         std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> load_clouds(
                 const CloudType::Type &cloud_type) override;

--- a/src/file/ScanFileHandler.h
+++ b/src/file/ScanFileHandler.h
@@ -40,17 +40,16 @@ namespace file {
          */
         ScanFileHandler(const char *scan_name);
 
-        void save_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+        void save_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                         const std::string &cloud_name,
-                        CloudType::Type cloud_type) override;
+                        const CloudType::Type &cloud_type) override;
 
-        void load_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+        void load_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                         const std::string &cloud_name,
-                        CloudType::Type cloud_type) override;
+                        const CloudType::Type &cloud_type) override;
 
-        void load_clouds(
-                std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &cloud_vector,
-                CloudType::Type cloud_type) override;
+        std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> load_clouds(
+                const CloudType::Type &cloud_type) override;
 
         std::string get_scan_name() override;
 
@@ -76,7 +75,9 @@ namespace file {
          * @param angle angle intervals of the scan.
          * @param cal calibration path.
          */
-        void update_info_json(std::string date, int angle, std::string cal = "None");
+        void update_info_json(const std::string &date,
+                              int angle,
+                              const std::string &cal = "None");
 
     private:
         /**
@@ -107,7 +108,7 @@ namespace file {
         /**
          * Update the settings.json file "latest_scan" field.
          */
-        void set_settings_latest_scan(boost::filesystem::path folder_path);
+        void set_settings_latest_scan(const boost::filesystem::path &folder_path);
 
     };
 }

--- a/src/model/calibration/Calibration.h
+++ b/src/model/calibration/Calibration.h
@@ -14,7 +14,7 @@ namespace calibration {
      * @param b rhs matrix.
      * @return origin point of the turntable in m.
      */
-    inline equations::Point calculate_center_pt(Eigen::MatrixXd A, Eigen::MatrixXd b) {
+    inline equations::Point calculate_center_pt(const Eigen::MatrixXd &A, const Eigen::MatrixXd &b) {
         Eigen::MatrixXd sol_mat = A.bdcSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(b);
         std::vector<double> sol_vec(sol_mat.data(), sol_mat.data() + sol_mat.rows() * sol_mat.cols());
         return equations::Point(sol_vec);
@@ -26,8 +26,8 @@ namespace calibration {
       * @param upright_planes vector of plane equations for the upright planes.
       * @return the A matrix (N-1, 3)
       */
-    inline Eigen::MatrixXd build_A_matrix(equations::Normal g_n,
-                                          std::vector<equations::Plane> upright_planes) {
+    inline Eigen::MatrixXd build_A_matrix(const equations::Normal &g_n,
+                                          const std::vector<equations::Plane> &upright_planes) {
         int rows = upright_planes.size() - 1;
         Eigen::MatrixXd A(rows, 3);
         for (int i = 0; i < rows; i++) {
@@ -48,8 +48,8 @@ namespace calibration {
       * @param upright_planes vector of plane equations for the upright planes.
       * @return the b matrix (1, N-1)
       */
-    inline Eigen::MatrixXd build_b_matrix(equations::Normal g_n,
-                                          std::vector<equations::Plane> upright_planes) {
+    inline Eigen::MatrixXd build_b_matrix(const equations::Normal &g_n,
+                                          const std::vector<equations::Plane> &upright_planes) {
         int rows = upright_planes.size() - 1;
         Eigen::MatrixXd b(rows, 1);
         for (int i = 0; i < rows; i++) {

--- a/src/model/equations/Normal.cpp
+++ b/src/model/equations/Normal.cpp
@@ -2,13 +2,13 @@
 
 equations::Normal::Normal(double A, double B, double C) : A(A), B(B), C(C) {}
 
-equations::Normal::Normal(std::vector<double> in) : A(in[0]), B(in[1]), C(in[2]) {
+equations::Normal::Normal(const std::vector<double> &in) : A(in[0]), B(in[1]), C(in[2]) {
     if (in.size() < 3) {
         throw std::invalid_argument("cannot create normal, input vector size too small");
     }
 }
 
-equations::Normal::Normal(pcl::ModelCoefficients::Ptr in) : A(in->values[0]), B(in->values[1]), C(in->values[2]) {}
+equations::Normal::Normal(const pcl::ModelCoefficients &in) : A(in.values[0]), B(in.values[1]), C(in.values[2]) {}
 
 equations::Normal equations::Normal::operator+(const equations::Normal &n2) const {
     return equations::Normal(A + n2.A, B + n2.B, C + n2.C);

--- a/src/model/equations/Normal.h
+++ b/src/model/equations/Normal.h
@@ -31,14 +31,14 @@ namespace equations {
          * @param in vector of three floats.
          * @throws invalid_argument if the vector contains too few coefficients.
          */
-        Normal(std::vector<double> in);
+        Normal(const std::vector<double> &in);
 
 
         /**
          * Initialize a normal given PCL ModelCoefficients.
          * @param in PCL coefficients of four coefficients (A,B,C,D) but will only use A,B,C
          */
-        Normal(pcl::ModelCoefficients::Ptr in);
+        Normal(const pcl::ModelCoefficients &in);
 
         /**
          * Overloaded addition + operator.

--- a/src/model/equations/Plane.cpp
+++ b/src/model/equations/Plane.cpp
@@ -11,7 +11,7 @@ equations::Plane::Plane(const std::shared_ptr<pcl::ModelCoefficients> &in) : A(i
 equations::Plane::Plane(const pcl::ModelCoefficients &in) : A(in.values[0]), B(in.values[1]),
                                                                              C(in.values[2]), D(in.values[3]) {}
 
-equations::Normal equations::Plane::get_normal() {
+equations::Normal equations::Plane::get_normal() const {
     return equations::Normal(this->A, this->B, this->C);
 }
 

--- a/src/model/equations/Plane.cpp
+++ b/src/model/equations/Plane.cpp
@@ -3,10 +3,13 @@
 
 equations::Plane::Plane(double A, double B, double C, double D) : A(A), B(B), C(C), D(D) {}
 
-equations::Plane::Plane(std::vector<double> in) : A(in[0]), B(in[1]), C(in[2]), D(in[3]) {}
+equations::Plane::Plane(const std::vector<double> &in) : A(in[0]), B(in[1]), C(in[2]), D(in[3]) {}
 
-equations::Plane::Plane(pcl::ModelCoefficients::Ptr in) : A(in->values[0]), B(in->values[1]),
+equations::Plane::Plane(const std::shared_ptr<pcl::ModelCoefficients> &in) : A(in->values[0]), B(in->values[1]),
                                                           C(in->values[2]), D(in->values[3]) {}
+
+equations::Plane::Plane(const pcl::ModelCoefficients &in) : A(in.values[0]), B(in.values[1]),
+                                                                             C(in.values[2]), D(in.values[3]) {}
 
 equations::Normal equations::Plane::get_normal() {
     return equations::Normal(this->A, this->B, this->C);

--- a/src/model/equations/Plane.h
+++ b/src/model/equations/Plane.h
@@ -58,7 +58,7 @@ namespace equations {
          * Generate normal from this plane.
          * @return the normal.
          */
-        Normal get_normal();
+        Normal get_normal() const;
 
         /**
          * Overloaded addition + operator.

--- a/src/model/equations/Plane.h
+++ b/src/model/equations/Plane.h
@@ -2,6 +2,7 @@
 #define SWAG_SCANNER_PLANE_H
 
 #include <pcl/ModelCoefficients.h>
+#include <memory>
 
 namespace equations {
 
@@ -35,16 +36,23 @@ namespace equations {
 
         /**
          * Initialize a plane given a vector.
+         * Note: I can use reference because primitive will get copied anyway.
          * @param in vector of four coefficients (A,B,C,D)
          * @throws invalid_argument if the vector is missing a coefficient.
          */
-        Plane(std::vector<double> in);
+        Plane(const std::vector<double> &in);
 
         /**
          * Initialize a plane given PCL ModelCoefficients.
          * @param in PCL coefficients of four coefficients (A,B,C,D)
          */
-        Plane(pcl::ModelCoefficients::Ptr in);
+        Plane(const std::shared_ptr<pcl::ModelCoefficients> &in);
+
+        /**
+         * Initialize a plane given PCL ModelCoefficients.
+         * @param in PCL coefficients of four coefficients (A,B,C,D)
+         */
+        Plane(const pcl::ModelCoefficients &in);
 
         /**
          * Generate normal from this plane.

--- a/src/model/equations/Point.cpp
+++ b/src/model/equations/Point.cpp
@@ -3,7 +3,7 @@
 
 equations::Point::Point(double x, double y, double z) : x(x), y(y), z(z) {}
 
-equations::Point::Point(std::vector<double> in) : x(in[0]), y(in[1]), z(in[2]) {
+equations::Point::Point(const std::vector<double> &in) : x(in[0]), y(in[1]), z(in[2]) {
     if (in.size() < 3) {
         throw std::invalid_argument("Cannot construct a point with fewer than three values");
     }

--- a/src/model/equations/Point.h
+++ b/src/model/equations/Point.h
@@ -14,7 +14,7 @@ namespace equations {
 
         Point(double x, double y, double z);
 
-        Point(std::vector<double> in);
+        Point(const std::vector<double> &in);
 
         ~Point() = default;
     } Point;

--- a/src/model/processing/Depth.cpp
+++ b/src/model/processing/Depth.cpp
@@ -3,7 +3,7 @@
 #include <librealsense2/rsutil.h>
 
 std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> depth::create_point_cloud(const std::vector<uint16_t> &depth_frame,
-                                                       const camera::intrinsics intrinsics) {
+                                                                          const camera::intrinsics &intrinsics) {
     // cloud setup
     auto cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     cloud->height = intrinsics.height;

--- a/src/model/processing/Depth.h
+++ b/src/model/processing/Depth.h
@@ -18,7 +18,7 @@ namespace depth {
      * @return a pointcloud.
      */
     std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> create_point_cloud(const std::vector<uint16_t> &depth_frame,
-                                                           const camera::intrinsics intrinsics);
+                                                                       const camera::intrinsics &intrinsics);
 }
 
 #endif //SWAG_SCANNER_DEPTH_H

--- a/src/model/processing/Filtering.cpp
+++ b/src/model/processing/Filtering.cpp
@@ -3,7 +3,7 @@
 #include <pcl/filters/voxel_grid.h>
 
 std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
-filtering::crop_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+filtering::crop_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                       float minX, float maxX,
                       float minY, float maxY,
                       float minZ, float maxZ) {
@@ -18,7 +18,7 @@ filtering::crop_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
 }
 
 std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
-filtering::voxel_grid_filter(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
+filtering::voxel_grid_filter(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
                              float leafSize) {
     auto cloud_filtered = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     pcl::VoxelGrid<pcl::PointXYZ> grid;

--- a/src/model/processing/Filtering.h
+++ b/src/model/processing/Filtering.h
@@ -15,10 +15,11 @@ namespace filtering {
      * @param cloud cloud you want to crop.
      * @return the cropped cloud.
      */
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> crop_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
-                                                   float minX, float maxX,
-                                                   float minY, float maxY,
-                                                   float minZ, float maxZ);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+    crop_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+               float minX, float maxX,
+               float minY, float maxY,
+               float minZ, float maxZ);
 
     /**
      * Downsample the given cloud using a voxel grid filter and leaf size.
@@ -26,8 +27,9 @@ namespace filtering {
      * @param leafSize size of leaf.
      * @return the filtered cloud.
      */
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> voxel_grid_filter(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
-                                                          float leafSize);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+    voxel_grid_filter(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+                      float leafSize);
 }
 
 #endif //SWAG_SCANNER_FILTERING_H

--- a/src/model/processing/Model.cpp
+++ b/src/model/processing/Model.cpp
@@ -157,7 +157,4 @@ void model::Model::sac_align_pair_clouds(const std::shared_ptr<pcl::PointCloud<p
                                         cloudAligned, transformation);
 }
 
-model::Model::~Model() {
-    std::cout << "calling model destructor \n";;
-}
 

--- a/src/model/processing/Model.h
+++ b/src/model/processing/Model.h
@@ -176,7 +176,7 @@ namespace model {
                                    Eigen::Matrix4f &transformation);
 
 
-        ~Model();
+        ~Model() = default;
 
     private:
 

--- a/src/model/processing/Model.h
+++ b/src/model/processing/Model.h
@@ -4,11 +4,12 @@
 #ifndef SWAG_SCANNER_MODEL_H
 #define SWAG_SCANNER_MODEL_H
 
+#include "CloudType.h"
 #include <Eigen/Dense>
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-#include "CloudType.h"
+#include <memory>
 
 namespace camera {
     class intrinsics;
@@ -16,7 +17,9 @@ namespace camera {
 
 namespace equations {
     class Normal;
+
     class Point;
+
     class Plane;
 }
 
@@ -38,24 +41,24 @@ namespace model {
         * @return a boost pointer to the new pointcloud.
         */
         std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> create_point_cloud(const std::vector<uint16_t> &depth_frame,
-                                                               const camera::intrinsics intrinsics);
+                                                                           const camera::intrinsics &intrinsics);
 
         /**
          * Take in a pointcloud, calculate the normals, and return a normal cloud.
          * @return a normal cloud.
          */
-        pcl::PointCloud<pcl::Normal>::Ptr estimate_normal_cloud(
-                std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> point_cloud);
+        std::shared_ptr<pcl::PointCloud<pcl::Normal>>
+        estimate_normal_cloud(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &point_cloud);
 
         /**
          * Given a cloud and its normal, calculate the features.
          * @param cloud the cloud you want to find features for.
-         * @param normalCloud normlas of cloud.
-         * @param features features.
+         * @param normal_cloud normals of cloud.
+         * @return the features of the given normal cloud.
          */
-        void compute_local_features(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
-                                    pcl::PointCloud<pcl::Normal>::Ptr normalCloud,
-                                    pcl::PointCloud<pcl::FPFHSignature33>::Ptr features);
+        pcl::PointCloud<pcl::FPFHSignature33>::Ptr compute_local_features(
+                const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+                const std::shared_ptr<pcl::PointCloud<pcl::Normal>> &normal_cloud);
 
         /**
          * Applies crop box filtering to remove outside points from cloud.
@@ -63,10 +66,11 @@ namespace model {
          * @param croppedCloud the cropped cloud.
          * @return the cropped cloud.
          */
-        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> crop_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
-                                                       float minX, float maxX,
-                                                       float minY, float maxY,
-                                                       float minZ, float maxZ);
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> crop_cloud(
+                const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+                float minX, float maxX,
+                float minY, float maxY,
+                float minZ, float maxZ);
 
         /**
          * Downsample the given cloud using voxel grid.
@@ -74,29 +78,32 @@ namespace model {
          * @param leafSize size of leaf.
          * @return the downsampled cloud.
          */
-        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> voxel_grid_filter(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
-                                                              float leafSize = .01);
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+        voxel_grid_filter(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+                          float leafSize = .01);
 
         /**
          * Get the upright and ground plane equations.
          * @param cloud calibration cloud.
          * @return vector of upright and ground plane equations.
          */
-        std::vector<equations::Plane> get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud);
+        std::vector<equations::Plane>
+        get_calibration_planes_coefs(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud);
 
         /**
          * Get the coefficients of the base plane of the given cloud.
          * @param cloud input cloud.
          * @return vector of size 4 of the plane coefficients.
          */
-        std::vector<float> get_plane_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud);
+        std::vector<float> get_plane_coefs(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud);
 
         /**
          * Remove scanning bed plane from the cloud.
          * @param cloudIn cloud you want to remove the plane from.
          * @return cloud with the remove plane
          */
-        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn);
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+        remove_plane(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn);
 
         /**
          * Given a vector of ground planes, calculate the axis direction by taking the
@@ -104,7 +111,7 @@ namespace model {
          * @param ground_planes vector of ground plane equations.
          * @return the axis direction.
          */
-        equations::Normal calculate_axis_dir(std::vector<equations::Plane> ground_planes);
+        equations::Normal calculate_axis_dir(const std::vector<equations::Plane> &ground_planes);
 
         /**
          * Calculate the origin point of the turntable using equation of rotation axis and equations
@@ -113,8 +120,8 @@ namespace model {
          * @param upright_planes vector of upright planes.
          * @return the origin point.
          */
-        equations::Point calculate_center_pt(equations::Normal axis_dir,
-                                             std::vector<equations::Plane> upright_planes);
+        equations::Point calculate_center_pt(const equations::Normal &axis_dir,
+                                             const std::vector<equations::Plane> &upright_planes);
 
 
         /**
@@ -125,10 +132,11 @@ namespace model {
          * @param theta angle in radians you want to rotate.
          * @return the rotated cloud.
          */
-        pcl::PointCloud<pcl::PointXYZ> rotate_cloud_about_line(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
-                                                                    std::vector<float> line_point,
-                                                                    std::vector<float> line_direction,
-                                                                    float theta);
+        pcl::PointCloud<pcl::PointXYZ>
+        rotate_cloud_about_line(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+                                const std::vector<float> &line_point,
+                                const std::vector<float> &line_direction,
+                                float theta);
 
         /**
          * Transform (translate and rotate) given cloud to center it at world origin coordinate (0,0,0)
@@ -139,20 +147,21 @@ namespace model {
          * @param ground_normal direction vector of ground.
          * @return
          */
-        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transform_cloud_to_world(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud,
-                                                                     pcl::PointXYZ center,
-                                                                     equations::Normal ground_normal);
+        std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
+        transform_cloud_to_world(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+                                 const pcl::PointXYZ &center,
+                                 const equations::Normal &ground_normal);
 
         /**
          * Use ICP to register an input and target cloud.
-         * @param cloudIn input cloud.
-         * @param cloudOut target cloud.
-         * @param transformedCloud the final transformed cloud.
+         * @param cloud_in input cloud.
+         * @param cloud_out target cloud.
+         * @param transformed_cloud the final transformed cloud.
          * @returns a transformation matrix from the source to target cloud.
          */
-        Eigen::Matrix4f icp_register_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
-                                                 std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOut,
-                                                 std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transformedCloud);
+        Eigen::Matrix4f icp_register_pair_clouds(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud_in,
+                                                 const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud_out,
+                                                 std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &transformed_cloud);
 
 
         /**
@@ -161,9 +170,9 @@ namespace model {
          * @param cloudTarget target cloud.
          * @param cloudAligned the aligned cloud.
          */
-        void sac_align_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
-                                   std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudTarget,
-                                   std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudAligned,
+        void sac_align_pair_clouds(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn,
+                                   const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudTarget,
+                                   const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudAligned,
                                    Eigen::Matrix4f &transformation);
 
 

--- a/src/model/processing/Registration.cpp
+++ b/src/model/processing/Registration.cpp
@@ -2,9 +2,9 @@
 #include <pcl/registration/icp.h>
 #include <pcl/registration/ia_ransac.h>
 
-Eigen::Matrix4f registration::icp_register_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
-                                                std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOut,
-                                                std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transformedCloud) {
+Eigen::Matrix4f registration::icp_register_pair_clouds(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn,
+                                                       const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudOut,
+                                                       const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &transformedCloud) {
     pcl::IterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ> icp;
     icp.setInputSource(cloudIn);
     icp.setInputTarget(cloudOut);
@@ -21,12 +21,12 @@ Eigen::Matrix4f registration::icp_register_pair_clouds(std::shared_ptr<pcl::Poin
     return icp.getFinalTransformation();
 }
 
-void registration::sac_align_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
-                                  std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudTarget,
-                                  pcl::PointCloud<pcl::FPFHSignature33>::Ptr cloudInFeatures,
-                                  pcl::PointCloud<pcl::FPFHSignature33>::Ptr cloudOutFeatures,
-                                  std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudAligned,
-                                  Eigen::Matrix4f &transformation) {
+void registration::sac_align_pair_clouds(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn,
+                                         const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudTarget,
+                                         const std::shared_ptr<pcl::PointCloud<pcl::FPFHSignature33>> &cloudInFeatures,
+                                         const std::shared_ptr<pcl::PointCloud<pcl::FPFHSignature33>> &cloudOutFeatures,
+                                         const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudAligned,
+                                         Eigen::Matrix4f &transformation) {
     pcl::SampleConsensusInitialAlignment<pcl::PointXYZ, pcl::PointXYZ, pcl::FPFHSignature33> reg;
     reg.setMinSampleDistance(0.05f);
     reg.setMaxCorrespondenceDistance(0.1);

--- a/src/model/processing/Registration.h
+++ b/src/model/processing/Registration.h
@@ -13,9 +13,9 @@ namespace registration {
      * @param transformedCloud empty cloud used as output.
      * @return transformation matrix source -> target.
      */
-    Eigen::Matrix4f icp_register_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
-                                             std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudOut,
-                                             std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> transformedCloud);
+    Eigen::Matrix4f icp_register_pair_clouds(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn,
+                                             const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudOut,
+                                             const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &transformedCloud);
 
     /**
      * Use SAC model to align cloud to target.
@@ -26,12 +26,12 @@ namespace registration {
      * @param cloudAligned output cloud source -> target.
      * @param transformation output transformation.
      */
-    void sac_align_pair_clouds(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudIn,
-                                      std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudTarget,
-                                      pcl::PointCloud<pcl::FPFHSignature33>::Ptr cloudInFeatures,
-                                      pcl::PointCloud<pcl::FPFHSignature33>::Ptr cloudOutFeatures,
-                                      std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloudAligned,
-                                      Eigen::Matrix4f &transformation);
+    void sac_align_pair_clouds(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn,
+                               const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudTarget,
+                               const std::shared_ptr<pcl::PointCloud<pcl::FPFHSignature33>> &cloudInFeatures,
+                               const std::shared_ptr<pcl::PointCloud<pcl::FPFHSignature33>> &cloudOutFeatures,
+                               const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudAligned,
+                               Eigen::Matrix4f &transformation);
 }
 
 #endif

--- a/src/model/processing/Segmentation.cpp
+++ b/src/model/processing/Segmentation.cpp
@@ -92,7 +92,7 @@ segmentation::get_calibration_planes_coefs(const std::shared_ptr<pcl::PointCloud
                   << coefficients->values[2] << " "
                   << coefficients->values[3] << std::endl;
         visual::Visualizer visualizer;
-        std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr> clouds{temp_cloud, cloud_plane};
+        std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> clouds{temp_cloud, cloud_plane};
         visualizer.simpleVis(clouds);
 
         // Remove the planar inliers, extract the rest

--- a/src/model/processing/Segmentation.cpp
+++ b/src/model/processing/Segmentation.cpp
@@ -8,7 +8,7 @@
 
 
 std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>
-segmentation::remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn) {
+segmentation::remove_plane(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud) {
     pcl::ModelCoefficients coefficients;
     auto inliers = std::make_shared<pcl::PointIndices>();
     auto cloud_inliers = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
@@ -23,7 +23,7 @@ segmentation::remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &clou
     seg.setMethodType(pcl::SAC_RANSAC);
     seg.setDistanceThreshold(0.005);
 
-    seg.setInputCloud(cloudIn);
+    seg.setInputCloud(cloud);
     seg.segment(*inliers, coefficients);
 
     if (inliers->indices.empty()) {
@@ -38,7 +38,7 @@ segmentation::remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &clou
 
     // Extract inliers
     pcl::ExtractIndices<pcl::PointXYZ> extract;
-    extract.setInputCloud(cloudIn);
+    extract.setInputCloud(cloud);
     extract.setIndices(inliers);
     extract.setNegative(false);            // Extract the inliers
     extract.filter(*cloud_inliers);        // cloud_inliers contains the plane
@@ -50,7 +50,7 @@ segmentation::remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &clou
 }
 
 std::vector<equations::Plane>
-segmentation::get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
+segmentation::get_calibration_planes_coefs(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud) {
     std::vector<equations::Plane> planes;
     // Create the segmentation object for the planar model and set all the parameters
     pcl::SACSegmentation<pcl::PointXYZ> seg;
@@ -72,7 +72,7 @@ segmentation::get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::
         // Segment the largest planar component from the remaining cloud
         seg.setInputCloud(temp_cloud);
         seg.segment(*inliers, *coefficients);
-        if (inliers->indices.size() == 0) {
+        if (inliers->indices.empty()) {
             std::cout << "Could not estimate a planar model for the given dataset." << std::endl;
             break;
         }
@@ -103,7 +103,7 @@ segmentation::get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::
     return planes;
 }
 
-std::vector<float> segmentation::get_plane_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud) {
+std::vector<float> segmentation::get_plane_coefs(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud) {
     pcl::PointIndices inliers;
     pcl::ModelCoefficients coefficients;
 

--- a/src/model/processing/Segmentation.h
+++ b/src/model/processing/Segmentation.h
@@ -13,10 +13,10 @@ namespace segmentation {
     /**
      * Given a cloud with plane, detect the plane using RANSAC, remove it, and return
      * a cloud without the plane.
-     * @param cloudIn cloud with plane.
+     * @param cloud cloud with plane.
      * @return cloud without plane.
      */
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> remove_plane(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloudIn);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> remove_plane(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud);
 
 
     /**
@@ -26,14 +26,14 @@ namespace segmentation {
      * @return a vector of coefficients for the two planes.
      * First element in vector is upright plane. Second element is ground plane.
      */
-    std::vector<equations::Plane> get_calibration_planes_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud);
+    std::vector<equations::Plane> get_calibration_planes_coefs(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud);
 
     /**
      * Get the plane coefficients of the base of the given cloud.
      * @param cloud input cloud.
      * @return coefficients vector of size 4 of the cloud.
      */
-    std::vector<float> get_plane_coefs(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> cloud);
+    std::vector<float> get_plane_coefs(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud);
 }
 
 #endif //SWAG_SCANNER_SEGMENTATION_H

--- a/src/utils/Algorithms.cpp
+++ b/src/utils/Algorithms.cpp
@@ -4,12 +4,12 @@
 #include "CameraTypes.h"
 
 pcl::PointXYZ algos::deproject_pixel_to_point(float x_pixel,
-                                                          float y_pixel,
-                                                          float z,
-                                                          const camera::intrinsics *intrinsics) {
-    float depth = z * intrinsics->depth_scale;
-    float x = (x_pixel - intrinsics->ppx) / intrinsics->fx;
-    float y = (y_pixel - intrinsics->ppy) / intrinsics->fy;
+                                              float y_pixel,
+                                              float z,
+                                              const camera::intrinsics &intrinsics) {
+    float depth = z * intrinsics.depth_scale;
+    float x = (x_pixel - intrinsics.ppx) / intrinsics.fx;
+    float y = (y_pixel - intrinsics.ppy) / intrinsics.fy;
     float ux = x * depth;
     float uy = y * depth;
 
@@ -17,10 +17,10 @@ pcl::PointXYZ algos::deproject_pixel_to_point(float x_pixel,
     return point;
 }
 
-pcl::PointXYZ algos::rotate_point_about_line(pcl::PointXYZ point,
-                                      std::vector<float> line_point,
-                                      std::vector<float> line_direction,
-                                      float theta) {
+pcl::PointXYZ algos::rotate_point_about_line(const pcl::PointXYZ &point,
+                                             const std::vector<float> &line_point,
+                                             const std::vector<float> &line_direction,
+                                             float theta) {
     float x = point.x;
     float y = point.y;
     float z = point.z;
@@ -42,8 +42,8 @@ pcl::PointXYZ algos::rotate_point_about_line(pcl::PointXYZ point,
     return p;
 }
 
-Eigen::Matrix4f algos::calc_transform_to_world_matrix(pcl::PointXYZ center,
-                                                      equations::Normal ground_normal) {
+Eigen::Matrix4f algos::calc_transform_to_world_matrix(const pcl::PointXYZ &center,
+                                                      const equations::Normal &ground_normal) {
     Eigen::Vector3f translation_vect(center.getVector3fMap());
     translation_vect = -translation_vect;
     Eigen::Translation<float, 3> translation(translation_vect);

--- a/src/utils/Algorithms.h
+++ b/src/utils/Algorithms.h
@@ -13,7 +13,9 @@ namespace camera {
 
 namespace equations {
     class Normal;
+
     class Plane;
+
     class Point;
 }
 
@@ -35,7 +37,7 @@ namespace algos {
     pcl::PointXYZ deproject_pixel_to_point(float x_pixel,
                                            float y_pixel,
                                            float z,
-                                           const camera::intrinsics *intrinsics);
+                                           const camera::intrinsics &intrinsics);
 
     /**
      * Given a copy of a point from the pointcloud, a point that a line passes through,
@@ -48,9 +50,9 @@ namespace algos {
      * @param line_direction direction vector (normalized) of the axis.
      * @return a new rotated point.
      */
-    pcl::PointXYZ rotate_point_about_line(pcl::PointXYZ point,
-                                          std::vector<float> line_point,
-                                          std::vector<float> line_direction,
+    pcl::PointXYZ rotate_point_about_line(const pcl::PointXYZ &point,
+                                          const std::vector<float> &line_point,
+                                          const std::vector<float> &line_direction,
                                           float theta);
 
     /**
@@ -59,8 +61,8 @@ namespace algos {
      * @param ground_normal normal vector of ground plane.
      * @return
      */
-    Eigen::Matrix4f calc_transform_to_world_matrix(pcl::PointXYZ center,
-                                                   equations::Normal ground_normal);
+    Eigen::Matrix4f calc_transform_to_world_matrix(const pcl::PointXYZ &center,
+                                                   const equations::Normal &ground_normal);
 }
 
 #endif //SWAG_SCANNER_ALGORITHMS_H

--- a/src/view/Visualizer.cpp
+++ b/src/view/Visualizer.cpp
@@ -9,7 +9,7 @@ using namespace std::chrono_literals;
 
 visual::Visualizer::Visualizer() {}
 
-void visual::Visualizer::simpleVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud) {
+void visual::Visualizer::simpleVis(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud) {
 
     pcl::visualization::PCLVisualizer viewer("3D viewer");
     viewer.setBackgroundColor(0, 0, 0);
@@ -23,7 +23,7 @@ void visual::Visualizer::simpleVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr clou
     }
 }
 
-void visual::Visualizer::simpleVis(std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr> clouds) {
+void visual::Visualizer::simpleVis(const std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &clouds) {
     pcl::visualization::PCLVisualizer viewer("3D viewer");
 
     int r = 255;
@@ -46,7 +46,7 @@ void visual::Visualizer::simpleVis(std::vector<pcl::PointCloud<pcl::PointXYZ>::C
     }
 }
 
-void visual::Visualizer::simpleVisColor(std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr> clouds) {
+void visual::Visualizer::simpleVisColor(const std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &clouds) {
     pcl::visualization::PCLVisualizer viewer("3D viewer");
 
     int b = 255;
@@ -72,7 +72,7 @@ void visual::Visualizer::simpleVisColor(std::vector<pcl::PointCloud<pcl::PointXY
     }
 }
 
-void visual::Visualizer::ptVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud, pcl::PointXYZ pt) {
+void visual::Visualizer::ptVis(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud, const pcl::PointXYZ &pt) {
     pcl::visualization::PCLVisualizer viewer("3D viewer");
     auto point = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     point->push_back(pt);
@@ -92,25 +92,8 @@ void visual::Visualizer::ptVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud, p
     }
 }
 
-
-void visual::Visualizer::normalsVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud,
-                                    pcl::PointCloud<pcl::Normal>::ConstPtr normals) {
-    pcl::visualization::PCLVisualizer viewer("3D viewer");
-    viewer.setBackgroundColor(0, 0, 0);
-    pcl::visualization::PointCloudGeometryHandlerXYZ<pcl::PointXYZ> rgb(cloud);
-    viewer.addPointCloud<pcl::PointXYZ>(cloud, rgb, "sample cloud");
-    viewer.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 3, "sample cloud");
-    viewer.addPointCloudNormals<pcl::PointXYZ, pcl::Normal>(cloud, normals, 10, 0.05, "normals");
-    viewer.addCoordinateSystem(1.0);
-    viewer.initCameraParameters();
-    while (!viewer.wasStopped()) {
-        viewer.spinOnce(100);
-        std::this_thread::sleep_for(100ms);
-    }
-}
-
-void visual::Visualizer::compareVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud1,
-                                    pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud2) {
+void visual::Visualizer::compareVis(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud1,
+                                    const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud2) {
     pcl::visualization::PCLVisualizer viewer("3D viewer");
     viewer.initCameraParameters();
 
@@ -136,7 +119,22 @@ void visual::Visualizer::compareVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr clo
         viewer.spinOnce(100);
         std::this_thread::sleep_for(100ms);
     }
+}
 
+void visual::Visualizer::normalsVis(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+                                    std::shared_ptr<pcl::PointCloud<pcl::Normal>> &normal) {
+    pcl::visualization::PCLVisualizer viewer("3D viewer");
+    viewer.setBackgroundColor(0, 0, 0);
+    pcl::visualization::PointCloudGeometryHandlerXYZ<pcl::PointXYZ> rgb(cloud);
+    viewer.addPointCloud<pcl::PointXYZ>(cloud, rgb, "sample cloud");
+    viewer.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 3, "sample cloud");
+    viewer.addPointCloudNormals<pcl::PointXYZ, pcl::Normal>(cloud, normal, 10, 0.05, "normals");
+    viewer.addCoordinateSystem(1.0);
+    viewer.initCameraParameters();
+    while (!viewer.wasStopped()) {
+        viewer.spinOnce(100);
+        std::this_thread::sleep_for(100ms);
+    }
 }
 
 

--- a/src/view/Visualizer.cpp
+++ b/src/view/Visualizer.cpp
@@ -121,8 +121,8 @@ void visual::Visualizer::compareVis(const std::shared_ptr<pcl::PointCloud<pcl::P
     }
 }
 
-void visual::Visualizer::normalsVis(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
-                                    std::shared_ptr<pcl::PointCloud<pcl::Normal>> &normal) {
+void visual::Visualizer::normalsVis(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+                                    const std::shared_ptr<pcl::PointCloud<pcl::Normal>> &normal) {
     pcl::visualization::PCLVisualizer viewer("3D viewer");
     viewer.setBackgroundColor(0, 0, 0);
     pcl::visualization::PointCloudGeometryHandlerXYZ<pcl::PointXYZ> rgb(cloud);

--- a/src/view/Visualizer.h
+++ b/src/view/Visualizer.h
@@ -47,8 +47,8 @@ namespace visual {
          * @param cloud base cloud.
          * @param normal normal cloud for base cloud.
          */
-        void normalsVis(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
-                        std::shared_ptr<pcl::PointCloud<pcl::Normal>> &normal);
+        void normalsVis(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+                        const std::shared_ptr<pcl::PointCloud<pcl::Normal>> &normal);
 
 
     private:

--- a/src/view/Visualizer.h
+++ b/src/view/Visualizer.h
@@ -1,5 +1,6 @@
 #include <thread>
 #include <pcl/common/common_headers.h>
+#include <memory>
 
 #ifndef SWAG_SCANNER_VISUALIZER_H
 #define SWAG_SCANNER_VISUALIZER_H
@@ -15,38 +16,39 @@ namespace visual {
          * Visualize one pointcloud
          * @param cloud pointcloud you want to visualize
          */
-        void simpleVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud);
+        void simpleVis(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud);
 
 
         /**
          * Visualize pointclouds. first cloud is white, then successive clouds are red and lighter shades of red.
          * @param clouds vector of pointcloud you want to visualize
          */
-        void simpleVis(std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr> clouds);
+        void simpleVis(const std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &clouds);
 
-        void simpleVisColor(std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr> clouds);
+        void simpleVisColor(const std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> &clouds);
 
         /**
          * Visualize a cloud and a point.
          * @param cloud the cloud.
          * @param pt the point.
          */
-        void ptVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud, pcl::PointXYZ pt);
+        void ptVis(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud, const pcl::PointXYZ &pt);
 
         /**
          * Visualize two point clouds side by side.
          * @param cloud1
          * @param cloud2
          */
-        void compareVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud1, pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud2);
+        void compareVis(const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud1,
+                        const std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud2);
 
         /**
          * Visualize normal vectors.
          * @param cloud base cloud.
-         * @param normals normal cloud for base cloud.
+         * @param normal normal cloud for base cloud.
          */
-        void normalsVis(pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud,
-                                                          pcl::PointCloud<pcl::Normal>::ConstPtr normals);
+        void normalsVis(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> &cloud,
+                        std::shared_ptr<pcl::PointCloud<pcl::Normal>> &normal);
 
 
     private:

--- a/test/calibrationTests/CalibrationTests.cpp
+++ b/test/calibrationTests/CalibrationTests.cpp
@@ -101,7 +101,7 @@ TEST_F(CalibrationPhysicalFixture, VisualizePlaneCalibration) {
 
 
     visual::Visualizer visualizer;
-    std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr> clouds{cloudOut, transformed};
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> clouds{cloudOut, transformed};
     visualizer.simpleVis(clouds);
 
 }

--- a/test/utilsTests/AlgosTests.cpp
+++ b/test/utilsTests/AlgosTests.cpp
@@ -9,7 +9,6 @@
 #include <pcl/io/pcd_io.h>
 
 
-
 class AlgosFixture : public ::testing::Test {
 
 protected:
@@ -51,7 +50,7 @@ protected:
  * is good.
  */
 TEST_F(AlgosFixture, TestDeprojectNoDistortion) {
-    pcl::PointXYZ actual = algos::deproject_pixel_to_point(10, 10, 100, intrinsics_no_distoration);
+    pcl::PointXYZ actual = algos::deproject_pixel_to_point(10, 10, 100, *intrinsics_no_distoration);
 
     pcl::PointXYZ expected;
     expected.x = -.0063134059;
@@ -67,7 +66,7 @@ TEST_F(AlgosFixture, TestDeprojectNoDistortion) {
  * Tests deprojection method with distortion coefficients.
  */
 TEST_F(AlgosFixture, TestDeprojectDistortion) {
-    pcl::PointXYZ actual = algos::deproject_pixel_to_point(10, 10, 100, intrinsics_distoration);
+    pcl::PointXYZ actual = algos::deproject_pixel_to_point(10, 10, 100, *intrinsics_distoration);
 
     pcl::PointXYZ expected;
     expected.x = -.0063134059;
@@ -126,7 +125,7 @@ TEST_F(AlgosFixture, TestTransformCoordinate) {
                                       -.03, .05);
 
     visual::Visualizer visualizer;
-    std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr> clouds{cloud_in, result};
+    std::vector<std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>>> clouds{cloud_in, result};
 //    std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr> clouds{result, result_cropped};
     visualizer.simpleVisColor(clouds);
 //    visualizer.ptVis(cloudIn, pt);


### PR DESCRIPTION
- cleaned up loose ends from smart-pointer-refactor branch.
- changed most method signatures to pass by ref instead of pass by value
- changed single return methods to actually return a value instead of using return parameters, see load_clouds and load_cloud methods